### PR TITLE
Fix Instances of compiler warning C4099

### DIFF
--- a/src/engine/interface/ui.cpp
+++ b/src/engine/interface/ui.cpp
@@ -199,7 +199,7 @@ namespace UI
             Change_Blend  = 1 << 2
         };
     }
-    struct Object;
+    class Object;
 
     static Object *buildparent = nullptr;
     static int buildchild = -1;

--- a/src/engine/model/animmodel.h
+++ b/src/engine/model/animmodel.h
@@ -48,7 +48,7 @@ struct animmodel : model
     };
 
     struct linkedpart;
-    struct Mesh;
+    class Mesh;
 
     struct shaderparams
     {

--- a/src/engine/model/skelmodel.h
+++ b/src/engine/model/skelmodel.h
@@ -10,7 +10,7 @@ enum
     Bonemask_Bone = 0x7FFF
 };
 
-struct skelhitdata; //defined in hitzone.h
+class skelhitdata; //defined in hitzone.h
 
 struct skelmodel : animmodel
 {


### PR DESCRIPTION
The prototypes for `Object`, `Mesh`, and `skelhitdata` are labelled `struct` when they are later defined to be `class`.
I have edited these prototypes to the correct declarations.
This fixes issue #213.