### PR TITLE
Add Windows build CI

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -4,7 +4,7 @@ on: [push]
 
 env:
   # Path to the solution file relative to the root of the project.
-  SOLUTION_FILE_PATH: .
+  SOLUTION_FILE_PATH: ./src/vcpp/libprimis.sln
 
   # Configuration type to build.
   # You can convert this to a build matrix if you need coverage of multiple configuration types.

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,41 @@
+name: MSBuild
+
+on: [push]
+
+env:
+  # Path to the solution file relative to the root of the project.
+  SOLUTION_FILE_PATH: .
+
+  # Configuration type to build.
+  # You can convert this to a build matrix if you need coverage of multiple configuration types.
+  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  BUILD_CONFIGURATION: Release
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - name: Clone repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Restore NuGet packages
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+      
+    - name: Upload libprimis.lib artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: libprimis-windows
+        path: ./bin64/libprimis.lib

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -24,9 +24,10 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
 
-    - name: Restore NuGet packages
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+#     errors due to this project not using NuGet
+#    - name: Restore NuGet packages
+#      working-directory: ${{env.GITHUB_WORKSPACE}}
+#      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
 
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}


### PR DESCRIPTION
This uses Github CI to build copies of the libprimis library for Windows, then uploads the binary as an artifact.
Closes #219.

Please only create pull requests that close an open issue; if you would like to
make a change to the game, please create an issue first that can be verified before
creating a pull request. Unsolicited pull requests without a corresponding issue
may be closed and ignored with no further feedback given.

Thanks for contributing to Imprimis!

=== LEGAL NOTICE ===

By creating a pull request, and in lieu of explicit licensing terms provided,
you agree to release the work contained therein under license terms compatible
with the Imprimis project; that is, under CC-BY-SA (for assets) or the zlib
license (for code). This license grant is provided regardless of the merge of
content or code with the engine and is irrevocable (like all other open source
licenses require).

If you do not want to contribute your code as being part of the generic Imprimis
project copyright, or would like to opt out of providing copyright immediately
upon the creation of the pull request, please make sure that your pull request
specifically addresses this. Note that the project cannot accept content
licenced under GPL licenses or other, more strict licensing terms; all content
is to be licenced permissively.
