### PR TITLE
Add `AUDIODRIVER` definitions for non-Windows systems

### DIFF
--- a/src/engine/interface/sound.cpp
+++ b/src/engine/interface/sound.cpp
@@ -224,7 +224,7 @@ void stopmusic()
 #ifdef WIN32
     #define AUDIODRIVER "directsound winmm"
 #else
-    #define AUDIODRIVER ""
+    #define AUDIODRIVER "pulseaudio alsa arts esd jack pipewire dsp"
 #endif
 
 bool shouldinitaudio = true;


### PR DESCRIPTION
When starting Imprimis (or presumably any libprimis application), an
error log stating `sound init failed: Audio target '' not available`
will appear. Upon investigation, it was found that this is caused by the
`audiodriver` array and its source `AUDIODRIVER` constant not being 
defined in `sound.cpp`. Defining the valid (Linux) audio drivers fixes this issue.

This patch will fix #221.
Please only create pull requests that close an open issue; if you would like to
make a change to the game, please create an issue first that can be verified before
creating a pull request. Unsolicited pull requests without a corresponding issue
may be closed and ignored with no further feedback given.

Thanks for contributing to Imprimis!

=== LEGAL NOTICE ===

By creating a pull request, and in lieu of explicit licensing terms provided,
you agree to release the work contained therein under license terms compatible
with the Imprimis project; that is, under CC-BY-SA (for assets) or the zlib
license (for code). This license grant is provided regardless of the merge of
content or code with the engine and is irrevocable (like all other open source
licenses require).

If you do not want to contribute your code as being part of the generic Imprimis
project copyright, or would like to opt out of providing copyright immediately
upon the creation of the pull request, please make sure that your pull request
specifically addresses this. Note that the project cannot accept content
licenced under GPL licenses or other, more strict licensing terms; all content
is to be licenced permissively.
