### PR TITLE
Move VFC vars and functions into an object

### DIFF
--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -240,8 +240,6 @@ extern float alphafrontsx1, alphafrontsx2, alphafrontsy1, alphafrontsy2, alphaba
 extern uint alphatiles[lighttilemaxheight];
 extern vtxarray *visibleva;
 
-extern void visiblecubes(bool cull = true);
-extern void setvfcP(const vec &bbmin = vec(-1, -1, -1), const vec &bbmax = vec(1, 1, 1));
 extern void rendergeom();
 extern int findalphavas();
 extern void renderrefractmask();
@@ -252,9 +250,6 @@ extern bool renderexplicitsky(bool outline = false);
 extern void cleanupva();
 extern bvec outlinecolor;
 
-extern bool isfoggedsphere(float rad, const vec &cv);
-extern int isvisiblesphere(float rad, const vec &cv);
-extern int isvisiblebb(const ivec &bo, const ivec &br);
 extern bool bboccluded(const ivec &bo, const ivec &br);
 
 extern int deferquery;

--- a/src/engine/render/grass.cpp
+++ b/src/engine/render/grass.cpp
@@ -10,6 +10,7 @@
 #include "grass.h"
 #include "octarender.h"
 #include "rendergl.h"
+#include "renderva.h"
 
 #include "interface/control.h"
 
@@ -275,7 +276,7 @@ namespace //internal functionality not seen by other files
         for(int i = 0; i < va->grasstris.length(); i++)
         {
             grasstri &g = va->grasstris[i];
-            if(isfoggedsphere(g.radius, g.center))
+            if(view.isfoggedsphere(g.radius, g.center))
             {
                 continue;
             }

--- a/src/engine/render/rendergl.cpp
+++ b/src/engine/render/rendergl.cpp
@@ -22,6 +22,7 @@
 #include "renderparticles.h"
 #include "rendersky.h"
 #include "rendertimers.h"
+#include "renderva.h"
 #include "renderwindow.h"
 #include "water.h"
 
@@ -1831,7 +1832,7 @@ void drawminimap(int yaw, int pitch, vec loc)
     ldrscale = 1;
     ldrscaleb = ldrscale/255;
 
-    visiblecubes(false);
+    view.visiblecubes(false);
     rendergbuffer();
     rendershadowatlas();
 
@@ -2026,7 +2027,7 @@ void gl_drawview(void (*gamefxn)(), void(*hudfxn)(), void(*editfxn)())
     ldrscale = 0.5f;
     ldrscaleb = ldrscale/255;
     //do occlusion culling
-    visiblecubes();
+    view.visiblecubes();
     //set to wireframe if applicable
     if(wireframe && editmode)
     {

--- a/src/engine/render/renderlights.cpp
+++ b/src/engine/render/renderlights.cpp
@@ -17,6 +17,7 @@
 #include "rendermodel.h"
 #include "rendersky.h"
 #include "rendertimers.h"
+#include "renderva.h"
 #include "renderwindow.h"
 #include "stain.h"
 
@@ -3061,7 +3062,7 @@ void collectlights()
             {
                 continue;
             }
-            if(smviscull && isfoggedsphere(e->attr1, e->o))
+            if(smviscull && view.isfoggedsphere(e->attr1, e->o))
             {
                 continue;
             }

--- a/src/engine/render/rendermodel.cpp
+++ b/src/engine/render/rendermodel.cpp
@@ -13,6 +13,7 @@
 #include "radiancehints.h"
 #include "rendergl.h"
 #include "rendermodel.h"
+#include "renderva.h"
 #include "renderwindow.h"
 
 #include "interface/console.h"
@@ -775,7 +776,7 @@ static int cullmodel(model *m, const vec &center, float radius, int flags, dynen
     {
         return Model_CullDist;
     }
-    if(flags&Model_CullVFC && isfoggedsphere(radius, center))
+    if(flags&Model_CullVFC && view.isfoggedsphere(radius, center))
     {
         return Model_CullVFC;
     }

--- a/src/engine/render/renderparticles.cpp
+++ b/src/engine/render/renderparticles.cpp
@@ -14,6 +14,7 @@
 
 #include "rendergl.h"
 #include "renderparticles.h"
+#include "renderva.h"
 #include "renderwindow.h"
 #include "rendertext.h"
 #include "stain.h"
@@ -1200,7 +1201,7 @@ struct fireballrenderer : listrenderer
               size = p->fade ? static_cast<float>(ts)/p->fade : 1,
               psize = p->size + pmax * size;
 
-        if(isfoggedsphere(psize*wobble, p->o))
+        if(view.isfoggedsphere(psize*wobble, p->o))
         {
             return;
         }
@@ -2005,7 +2006,7 @@ void updateparticles()
             }
             if(cullparticles && pe.maxfade >= 0)
             {
-                if(isfoggedsphere(pe.radius, pe.center))
+                if(view.isfoggedsphere(pe.radius, pe.center))
                 {
                     pe.lastcull = lastmillis;
                     continue;

--- a/src/engine/render/rendersky.cpp
+++ b/src/engine/render/rendersky.cpp
@@ -15,6 +15,7 @@
 #include "octarender.h"
 #include "rendergl.h"
 #include "rendersky.h"
+#include "renderva.h"
 
 #include "interface/console.h"
 #include "interface/control.h"
@@ -332,7 +333,7 @@ void drawskybox(bool clear)
         for(vtxarray *va = visibleva; va; va = va->next)
         {
             if(va->sky && va->occluded < Occlude_BB &&
-               ((va->skymax.x >= 0 && isvisiblebb(va->skymin, ivec(va->skymax).sub(va->skymin)) != ViewFrustumCull_NotVisible) ||
+               ((va->skymax.x >= 0 && view.isvisiblebb(va->skymin, ivec(va->skymax).sub(va->skymin)) != ViewFrustumCull_NotVisible) ||
                 !insideworld(camera1->o)))
             {
                 limited = true;

--- a/src/engine/render/renderva.cpp
+++ b/src/engine/render/renderva.cpp
@@ -83,9 +83,6 @@ namespace
 
     ///////// view frustrum culling ///////////////////////
 
-    plane vfcP[5];  // perpindictular vectors to view frustrum bounding planes
-
-
     float vadist(vtxarray *va, const vec &p)
     {
         return p.dist_to_bb(va->bbmin, va->bbmax);

--- a/src/engine/render/renderva.cpp
+++ b/src/engine/render/renderva.cpp
@@ -81,11 +81,18 @@ namespace
 
     ///////// view frustrum culling ///////////////////////
 
+    struct vfc
+    {
+        plane vfcP[5];  // perpindictular vectors to view frustrum bounding planes
+        float vfcDfog;  // far plane culling distance (fog limit).
+        float vfcDnear[5], //near plane culling
+              vfcDfar[5];  //far plane culling
+    } view;
+
     plane vfcP[5];  // perpindictular vectors to view frustrum bounding planes
     float vfcDfog;  // far plane culling distance (fog limit).
     float vfcDnear[5], //near plane culling
           vfcDfar[5];  //far plane culling
-
 
     int isfoggedcube(const ivec &o, int size)
     {

--- a/src/engine/render/renderva.cpp
+++ b/src/engine/render/renderva.cpp
@@ -2385,7 +2385,10 @@ void drawbb(const ivec &bo, const ivec &br)
 
 void vfc::setvfcP(const vec &bbmin, const vec &bbmax)
 {
-    vec4 px = camprojmatrix.rowx(), py = camprojmatrix.rowy(), pz = camprojmatrix.rowz(), pw = camprojmatrix.roww();
+    vec4 px = camprojmatrix.rowx(),
+         py = camprojmatrix.rowy(),
+         pz = camprojmatrix.rowz(),
+         pw = camprojmatrix.roww();
     vfcP[0] = plane(vec4(pw).mul(-bbmin.x).add(px)).normalize(); // left plane
     vfcP[1] = plane(vec4(pw).mul(bbmax.x).sub(px)).normalize(); // right plane
     vfcP[2] = plane(vec4(pw).mul(-bbmin.y).add(py)).normalize(); // bottom plane

--- a/src/engine/render/renderva.h
+++ b/src/engine/render/renderva.h
@@ -6,14 +6,15 @@ class vfc
     public:
         int isfoggedcube(const ivec &o, int size);
         int isvisiblecube(const ivec &o, int size);
-        void calcvfcD();
         void visiblecubes(bool cull = true);
         bool isfoggedsphere(float rad, const vec &cv);
         int isvisiblesphere(float rad, const vec &cv);
         int isvisiblebb(const ivec &bo, const ivec &br);
-        void setvfcP(const vec &bbmin = vec(-1, -1, -1), const vec &bbmax = vec(1, 1, 1));
         int cullfrustumsides(const vec &lightpos, float lightradius, float size, float border);
     private:
+        void calcvfcD();
+        void setvfcP(const vec &bbmin = vec(-1, -1, -1), const vec &bbmax = vec(1, 1, 1));
+
         plane vfcP[5];  // perpindictular vectors to view frustrum bounding planes
         float vfcDfog;  // far plane culling distance (fog limit).
         float vfcDnear[5], //near plane culling

--- a/src/engine/render/renderva.h
+++ b/src/engine/render/renderva.h
@@ -1,0 +1,25 @@
+#ifndef RENDERVA_H_
+#define RENDERVA_H_
+
+class vfc
+{
+    public:
+        int isfoggedcube(const ivec &o, int size);
+        int isvisiblecube(const ivec &o, int size);
+        void calcvfcD();
+        void visiblecubes(bool cull = true);
+        bool isfoggedsphere(float rad, const vec &cv);
+        int isvisiblesphere(float rad, const vec &cv);
+        int isvisiblebb(const ivec &bo, const ivec &br);
+        void setvfcP(const vec &bbmin = vec(-1, -1, -1), const vec &bbmax = vec(1, 1, 1));
+        int cullfrustumsides(const vec &lightpos, float lightradius, float size, float border);
+    private:
+        plane vfcP[5];  // perpindictular vectors to view frustrum bounding planes
+        float vfcDfog;  // far plane culling distance (fog limit).
+        float vfcDnear[5], //near plane culling
+              vfcDfar[5];  //far plane culling
+};
+
+extern vfc view;
+
+#endif

--- a/src/engine/world/dynlight.cpp
+++ b/src/engine/world/dynlight.cpp
@@ -15,6 +15,7 @@
 #include "interface/control.h"
 
 #include "render/rendergl.h"
+#include "render/renderva.h"
 
 //internally relevant functionality
 namespace
@@ -185,7 +186,7 @@ int finddynlights()
             continue;
         }
         d.dist = camera1->o.dist(d.o) - d.curradius;
-        if(d.dist > dynlightdist || isfoggedsphere(d.curradius, d.o))
+        if(d.dist > dynlightdist || view.isfoggedsphere(d.curradius, d.o))
         {
             continue;
         }

--- a/src/engine/world/octaedit.cpp
+++ b/src/engine/world/octaedit.cpp
@@ -25,6 +25,8 @@
 #include "render/hud.h"
 #include "render/octarender.h"
 #include "render/rendergl.h"
+#include "render/renderva.h"
+
 
 #include "world/material.h"
 
@@ -240,7 +242,7 @@ bool haveselent()
     return entgroup.length() > 0;
 }
 
-bool noedit(bool view, bool msg)
+bool noedit(bool inview, bool msg)
 {
     if(!editmode)
     {
@@ -250,7 +252,7 @@ bool noedit(bool view, bool msg)
         }
         return true;
     }
-    if(view || haveselent())
+    if(inview || haveselent())
     {
         return false;
     }
@@ -258,7 +260,7 @@ bool noedit(bool view, bool msg)
     s.mul(sel.grid / 2.0f);
     o.add(s);
     float r = std::max(std::max(s.x, s.y), s.z);
-    bool viewable = (isvisiblesphere(r, o) != ViewFrustumCull_NotVisible);
+    bool viewable = view.isvisiblesphere(r, o) != ViewFrustumCull_NotVisible;
     if(!viewable && msg)
     {
         conoutf(Console_Error, "selection not in view");


### PR DESCRIPTION
This PR creates a singleton object containing the view frustum culling variables and related functions. All of the formerly global variables are now private, and most of the functions are exposed as public member functions (though a couple are private). The singleton object created is a global variable named `view` (this can be changed later). A new header file, `renderva.h`, has been created to place the `vfc` object definition.

This PR does not change any behavior and only affects the code architecture to encapsulate formerly globally accessible variables. Additional reductions in interconnectivity can be done, but are not the objective of this PR.

![vfc](https://user-images.githubusercontent.com/23445929/143727567-39d271d7-1166-46a6-8fca-d9351f22bb14.png)
