### PR TITLE
Move g-buffer vars & fns into an object

### DIFF
--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -150,7 +150,6 @@ extern void loaddeferredlightshaders();
 extern void cleardeferredlightshaders();
 extern void clearshadowcache();
 
-extern void rendervolumetric();
 extern void cleanupvolumetric();
 
 extern void findshadowvas();
@@ -204,19 +203,13 @@ inline void dummyfxn()
 
 extern void resolvemsaacolor(int w, int h);
 extern bool shouldworkinoq();
-extern void cleanupgbuffer();
 extern void initgbuffer();
 extern bool usepacknorm();
 extern void maskgbuffer(const char *mask);
-extern void bindgdepth();
-extern void preparegbuffer(bool depthclear = true);
 extern void rendergbuffer(bool depthclear = true, void (*gamefxn)() = dummyfxn);
 extern void shadegbuffer();
 extern void shademinimap(const vec &color = vec(-1, -1, -1));
-extern void shademodelpreview(int x, int y, int w, int h, bool background = true, bool scissor = false);
-extern void renderao();
 extern void setuplights();
-extern void setupgbuffer();
 extern GLuint shouldscale();
 extern void doscale(GLuint outfbo = 0);
 extern bool debuglights();

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -121,7 +121,6 @@ extern int debugfullscreen;
 extern matrix4 eyematrix;
 extern GLuint mshdrtex, mshdrfbo, msrefractfbo;
 extern int msaaedgedetect;
-extern GLuint refractfbo, refracttex;
 extern int hdrclear;
 
 extern int msaatonemap;
@@ -184,7 +183,6 @@ inline bool bbinsidespot(const vec &origin, const vec &dir, int spot, const ivec
 extern matrix4 worldmatrix, screenmatrix;
 
 extern int gw, gh, gdepthformat, ghasstencil;
-extern GLuint gdepthtex, gcolortex, gnormaltex, gglowtex, gdepthrb, gstencilrb;
 extern int msaasamples, msaalight;
 extern GLuint msdepthtex, mscolortex, msnormaltex, msglowtex, msdepthrb, msstencilrb;
 extern std::vector<vec2> msaapositions;
@@ -192,7 +190,7 @@ extern std::vector<vec2> msaapositions;
 extern bool inoq;
 extern int rhinoq;
 extern int rsmcull;
-extern GLuint gfbo, msfbo, rhfbo;
+extern GLuint msfbo, rhfbo;
 
 //allows passing nothing to internal uses of gbuffer fxn
 //(the parameter is for taking a game function to be rendered onscreen)

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -186,7 +186,7 @@ extern std::vector<vec2> msaapositions;
 extern bool inoq;
 extern int rhinoq;
 extern int rsmcull;
-extern GLuint msfbo, rhfbo;
+extern GLuint rhfbo;
 
 //allows passing nothing to internal uses of gbuffer fxn
 //(the parameter is for taking a game function to be rendered onscreen)

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -118,7 +118,6 @@ extern int spotlights;
 extern int volumetriclights;
 extern int nospeclights;
 extern int debugfullscreen;
-extern matrix4 eyematrix;
 extern int msaaedgedetect;
 extern int hdrclear;
 

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -136,7 +136,7 @@ enum
 extern int shadowmapping;
 extern int smcullside;
 
-extern matrix4 shadowmatrix, linearworldmatrix;
+extern matrix4 shadowmatrix;
 
 extern void setbilateralshader(int radius, int pass, float depth);
 void clearbilateralshaders();

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -202,8 +202,6 @@ extern void maskgbuffer(const char *mask);
 extern void rendergbuffer(bool depthclear = true, void (*gamefxn)() = dummyfxn);
 extern void shadegbuffer();
 extern void setuplights();
-extern GLuint shouldscale();
-extern void doscale(GLuint outfbo = 0);
 extern bool debuglights();
 extern void cleanuplights();
 

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -119,7 +119,6 @@ extern int volumetriclights;
 extern int nospeclights;
 extern int debugfullscreen;
 extern matrix4 eyematrix;
-extern GLuint mshdrtex, mshdrfbo, msrefractfbo;
 extern int msaaedgedetect;
 extern int hdrclear;
 
@@ -139,7 +138,6 @@ extern int shadowmapping;
 extern int smcullside;
 
 extern matrix4 shadowmatrix, linearworldmatrix;
-extern GLuint msrefracttex;
 
 extern void setbilateralshader(int radius, int pass, float depth);
 void clearbilateralshaders();
@@ -164,7 +162,6 @@ extern void renderrsmgeom(bool dyntex = false);
 extern void workinoq();
 
 extern int calcspheresidemask(const vec &p, float radius, float bias);
-extern int cullfrustumsides(const vec &lightpos, float lightradius, float size, float border);
 extern int calcbbrsmsplits(const ivec &bbmin, const ivec &bbmax);
 extern int calcspherersmsplits(const vec &center, float radius);
 
@@ -184,7 +181,6 @@ extern matrix4 worldmatrix, screenmatrix;
 
 extern int gw, gh, gdepthformat, ghasstencil;
 extern int msaasamples, msaalight;
-extern GLuint msdepthtex, mscolortex, msnormaltex, msglowtex, msdepthrb, msstencilrb;
 extern std::vector<vec2> msaapositions;
 
 extern bool inoq;
@@ -199,14 +195,12 @@ inline void dummyfxn()
     return;
 }
 
-extern void resolvemsaacolor(int w, int h);
 extern bool shouldworkinoq();
 extern void initgbuffer();
 extern bool usepacknorm();
 extern void maskgbuffer(const char *mask);
 extern void rendergbuffer(bool depthclear = true, void (*gamefxn)() = dummyfxn);
 extern void shadegbuffer();
-extern void shademinimap(const vec &color = vec(-1, -1, -1));
 extern void setuplights();
 extern GLuint shouldscale();
 extern void doscale(GLuint outfbo = 0);

--- a/src/engine/render/aa.cpp
+++ b/src/engine/render/aa.cpp
@@ -1187,29 +1187,29 @@ bool multisampledaa()
  *
  * does not apply to multisample aa, msaa is not a screenspace aa
  *
- * function pointer resolve is used to setup the fbo for the specified aa
+ * method pointer resolve is used to setup the fbo for the specified aa
  */
-void doaa(GLuint outfbo, void (*resolve)(GLuint, int))
+void doaa(GLuint outfbo, GBuffer gbuffer)
 {
     if(smaa)
     {
         bool split = multisampledaa();
-        resolve(smaafbo[0], smaatype);
+        gbuffer.processhdr(smaafbo[0], smaatype);
         dosmaa(outfbo, split);
     }
     else if(fxaa)
     {
-        resolve(fxaafbo, fxaatype);
+        gbuffer.processhdr(fxaafbo, fxaatype);
         dofxaa(outfbo);
     }
     else if(tqaa)
     {
-        resolve(tqaafbo[0], tqaatype);
+        gbuffer.processhdr(tqaafbo[0], tqaatype);
         dotqaa(outfbo);
     }
     else
     {
-        resolve(outfbo, AA_Unused);
+        gbuffer.processhdr(outfbo, AA_Unused);
     }
 }
 

--- a/src/engine/render/aa.cpp
+++ b/src/engine/render/aa.cpp
@@ -10,6 +10,7 @@
 #include "aa.h"
 #include "hdr.h"
 #include "rendergl.h"
+#include "renderlights.h"
 #include "rendertimers.h"
 #include "renderwindow.h"
 
@@ -60,7 +61,7 @@ namespace //internal functions incl. AA implementations
             glBindFramebuffer_(GL_FRAMEBUFFER, tqaafbo[i]);
             createtexture(tqaatex[i], w, h, nullptr, 3, 1, GL_RGBA8, GL_TEXTURE_RECTANGLE);
             glFramebufferTexture2D_(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE, tqaatex[i], 0);
-            bindgdepth();
+            gbuf.bindgdepth();
             if(glCheckFramebufferStatus_(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
             {
                 fatal("failed allocating TQAA buffer!");
@@ -127,7 +128,7 @@ namespace //internal functions incl. AA implementations
         glBindTexture(GL_TEXTURE_RECTANGLE, tqaatex[0]);
         glActiveTexture_(GL_TEXTURE1);
         glBindTexture(GL_TEXTURE_RECTANGLE, tqaaframe ? tqaatex[1] : tqaatex[0]);
-        setaavelocityparams(GL_TEXTURE2);
+        gbuf.setaavelocityparams(GL_TEXTURE2);
         glActiveTexture_(GL_TEXTURE0);
         vec4 quincunx(0, 0, 0, 0);
         if(tqaaquincunx)
@@ -209,7 +210,7 @@ namespace //internal functions incl. AA implementations
         glBindFramebuffer_(GL_FRAMEBUFFER, fxaafbo);
         createtexture(fxaatex, w, h, nullptr, 3, 1, tqaa || (!fxaagreenluma && !intel_texalpha_bug) ? GL_RGBA8 : GL_RGB, GL_TEXTURE_RECTANGLE);
         glFramebufferTexture2D_(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE, fxaatex, 0);
-        bindgdepth();
+        gbuf.bindgdepth();
         if(glCheckFramebufferStatus_(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
         {
             fatal("failed allocating FXAA buffer!");
@@ -260,8 +261,8 @@ namespace //internal functions incl. AA implementations
 
     void cleanupsmaa(); //fxn prototype required due to VARFP initialization chicken/egg
 
-    VARFP(smaa, 0, 0, 1, cleanupgbuffer()); //toggles smaa
-    VARFP(smaaspatial, 0, 1, 1, cleanupgbuffer());
+    VARFP(smaa, 0, 0, 1, gbuf.cleanupgbuffer()); //toggles smaa
+    VARFP(smaaspatial, 0, 1, 1, gbuf.cleanupgbuffer());
     VARFP(smaaquality, 0, 2, 3, cleanupsmaa());
     VARFP(smaacoloredge, 0, 0, 1, cleanupsmaa()); //toggle between color & luma edge shaders
     VARFP(smaagreenluma, 0, 0, 1, cleanupsmaa());
@@ -824,7 +825,7 @@ namespace //internal functions incl. AA implementations
             }
             if(!i || (smaadepthmask && (!tqaa || msaalight)) || (smaastencil && ghasstencil > (msaasamples ? 1 : 0)))
             {
-                bindgdepth();
+                gbuf.bindgdepth();
             }
             if(glCheckFramebufferStatus_(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
             {
@@ -1039,7 +1040,7 @@ namespace //internal functions incl. AA implementations
 }
 
 //for temporal aa, called externally
-void setaavelocityparams(GLenum tmu)
+void GBuffer::setaavelocityparams(GLenum tmu)
 {
     glActiveTexture_(tmu);
     if(msaalight)

--- a/src/engine/render/aa.h
+++ b/src/engine/render/aa.h
@@ -1,5 +1,8 @@
 #ifndef AA_H_
 #define AA_H_
+
+class GBuffer;
+
 extern matrix4 nojittermatrix;
 
 extern void setupaa(int w, int h);
@@ -8,7 +11,7 @@ extern bool multisampledaa();
 extern void setaamask(bool val);
 extern void enableaamask(int stencil = 0);
 extern void disableaamask();
-extern void doaa(GLuint outfbo, void (*resolve)(GLuint, int));
+extern void doaa(GLuint outfbo, GBuffer gbuffer);
 extern bool debugaa();
 extern void cleanupaa();
 

--- a/src/engine/render/aa.h
+++ b/src/engine/render/aa.h
@@ -5,7 +5,6 @@ extern matrix4 nojittermatrix;
 extern void setupaa(int w, int h);
 extern void jitteraa();
 extern bool multisampledaa();
-extern void setaavelocityparams(GLenum tmu = GL_TEXTURE0);
 extern void setaamask(bool val);
 extern void enableaamask(int stencil = 0);
 extern void disableaamask();

--- a/src/engine/render/ao.cpp
+++ b/src/engine/render/ao.cpp
@@ -11,6 +11,7 @@
 
 #include "ao.h"
 #include "rendergl.h"
+#include "renderlights.h"
 #include "rendertimers.h"
 #include "renderwindow.h"
 
@@ -233,7 +234,7 @@ void viewao()
     debugquad(0, 0, w, h, 0, 0, tw, th);
 }
 
-void renderao()
+void GBuffer::renderao()
 {
     if(!ao)
     {

--- a/src/engine/render/hdr.cpp
+++ b/src/engine/render/hdr.cpp
@@ -254,7 +254,7 @@ void loadhdrshaders(int aa)
     }
 }
 
-void processhdr(GLuint outfbo, int aa)
+void GBuffer::processhdr(GLuint outfbo, int aa)
 {
     timer *hdrtimer = begintimer("hdr processing");
 

--- a/src/engine/render/hdr.cpp
+++ b/src/engine/render/hdr.cpp
@@ -17,6 +17,7 @@
 #include "aa.h"
 #include "hdr.h"
 #include "rendergl.h"
+#include "renderlights.h"
 #include "rendertimers.h"
 
 #include "interface/control.h"
@@ -159,7 +160,7 @@ void cleanupbloom()
 }
 
 FVARFP(hdrgamma, 1e-3f, 2, 1e3f, initwarning("HDR setup", Init_Load, Change_Shaders));
-VARFP(hdrprec, 0, 2, 3, cleanupgbuffer()); //precision of hdr buffer
+VARFP(hdrprec, 0, 2, 3, gbuf.cleanupgbuffer()); //precision of hdr buffer
 
 void copyhdr(int sw, int sh, GLuint fbo, int dw, int dh, bool flipx, bool flipy, bool swapxy)
 {
@@ -504,7 +505,7 @@ void processhdr(GLuint outfbo, int aa)
             case AA_SplitMasked:
             {
                 SETSHADER(msaatonemapsplitmasked);
-                setaavelocityparams(GL_TEXTURE3);
+                gbuf.setaavelocityparams(GL_TEXTURE3);
                 break;
             }
             default:
@@ -547,7 +548,7 @@ void processhdr(GLuint outfbo, int aa)
                     goto done; //see bottom of fxn
                 }
                 SETSHADER(hdrtonemapmasked);
-                setaavelocityparams(GL_TEXTURE3);
+                gbuf.setaavelocityparams(GL_TEXTURE3);
                 break;
             }
             default:
@@ -585,7 +586,7 @@ void processhdr(GLuint outfbo, int aa)
                 case AA_Masked:
                 {
                     SETSHADER(msaatonemapmasked);
-                    setaavelocityparams(GL_TEXTURE3);
+                    gbuf.setaavelocityparams(GL_TEXTURE3);
                     break;
                 }
                 default:
@@ -623,7 +624,7 @@ void processhdr(GLuint outfbo, int aa)
                         case AA_Masked:
                         {
                             SETSHADER(hdrnopmasked);
-                            setaavelocityparams(GL_TEXTURE3);
+                            gbuf.setaavelocityparams(GL_TEXTURE3);
                             break;
                         }
                         default:

--- a/src/engine/render/hdr.cpp
+++ b/src/engine/render/hdr.cpp
@@ -175,7 +175,7 @@ void copyhdr(int sw, int sh, GLuint fbo, int dw, int dh, bool flipx, bool flipy,
 
     if(msaalight)
     {
-        resolvemsaacolor(sw, sh);
+        gbuf.resolvemsaacolor(sw, sh);
     }
     glerror();
 

--- a/src/engine/render/hdr.h
+++ b/src/engine/render/hdr.h
@@ -11,7 +11,6 @@ extern int  gethdrformat(int prec, int fallback = GL_RGB);
 extern void cleanupbloom();
 extern void setupbloom(int w, int h);
 extern void loadhdrshaders(int aa);
-extern void processhdr(GLuint outfbo, int aa);
 extern void copyhdr(int sw, int sh, GLuint fbo, int dw = 0, int dh = 0, bool flipx = false, bool flipy = false, bool swapxy = false);
 
 #endif

--- a/src/engine/render/radiancehints.cpp
+++ b/src/engine/render/radiancehints.cpp
@@ -21,6 +21,7 @@
 #include "octarender.h"
 #include "radiancehints.h"
 #include "rendergl.h"
+#include "renderlights.h"
 #include "rendermodel.h"
 #include "rendertimers.h"
 #include "renderwindow.h"
@@ -846,7 +847,7 @@ void radiancehints::renderslices()
     }
 }
 
-void renderradiancehints()
+void GBuffer::renderradiancehints()
 {
     if(rhinoq && !inoq && shouldworkinoq())
     {

--- a/src/engine/render/radiancehints.h
+++ b/src/engine/render/radiancehints.h
@@ -68,7 +68,6 @@ extern radiancehints rh;
 
 extern void clearradiancehintscache();
 extern bool useradiancehints();
-extern void renderradiancehints();
 extern void setupradiancehints();
 extern void cleanupradiancehints();
 

--- a/src/engine/render/renderalpha.cpp
+++ b/src/engine/render/renderalpha.cpp
@@ -12,6 +12,7 @@
 
 #include "hdr.h"
 #include "rendergl.h"
+#include "renderlights.h"
 #include "rendermodel.h"
 #include "renderparticles.h"
 #include "rendertimers.h"
@@ -46,24 +47,24 @@ namespace
             glStencilFunc(GL_NOTEQUAL, 0, 0x07);
             glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
             glEnable(GL_STENCIL_TEST);
-            renderparticles(ParticleLayer_Over);
+            gbuf.renderparticles(ParticleLayer_Over);
             glDisable(GL_STENCIL_TEST);
             if(scissor)
             {
                 glDisable(GL_SCISSOR_TEST);
             }
-            renderparticles(ParticleLayer_NoLayer);
+            gbuf.renderparticles(ParticleLayer_NoLayer);
         }
         else
         {
-            renderparticles();
+            gbuf.renderparticles();
         }
     }
 }
 
 //externally relevant functionality
 
-void rendertransparent()
+void GBuffer::rendertransparent()
 {
     int hasalphavas = findalphavas(),
         hasmats = findmaterials();
@@ -72,13 +73,13 @@ void rendertransparent()
     {
         if(!editmode)
         {
-            renderparticles();
+            gbuf.renderparticles();
         }
         return;
     }
     if(!editmode && particlelayers && ghasstencil)
     {
-        renderparticles(ParticleLayer_Under);
+        gbuf.renderparticles(ParticleLayer_Under);
     }
     timer *transtimer = begintimer("transparent");
     if(hasalphavas&4 || hasmats&4)

--- a/src/engine/render/renderalpha.h
+++ b/src/engine/render/renderalpha.h
@@ -2,6 +2,5 @@
 #define RENDERALPHA_H_
 
 extern int transparentlayer;
-extern void rendertransparent();
 
 #endif

--- a/src/engine/render/rendergl.cpp
+++ b/src/engine/render/rendergl.cpp
@@ -1986,7 +1986,7 @@ int xtraverts, xtravertsva;
 //main scene rendering function
 void gl_drawview(void (*gamefxn)(), void(*hudfxn)(), void(*editfxn)())
 {
-    GLuint scalefbo = shouldscale();
+    GLuint scalefbo = gbuf.shouldscale();
     if(scalefbo)
     {
         vieww = gw;
@@ -2123,7 +2123,7 @@ void gl_drawview(void (*gamefxn)(), void(*hudfxn)(), void(*editfxn)())
     renderpostfx(scalefbo);
     if(scalefbo)
     {
-        doscale();
+        gbuf.doscale();
     }
 }
 

--- a/src/engine/render/rendergl.cpp
+++ b/src/engine/render/rendergl.cpp
@@ -18,6 +18,7 @@
 #include "radiancehints.h"
 #include "renderalpha.h"
 #include "rendergl.h"
+#include "renderlights.h"
 #include "rendermodel.h"
 #include "renderparticles.h"
 #include "rendersky.h"
@@ -1903,7 +1904,7 @@ namespace modelpreview
         modelpreview::background = background;
         modelpreview::scissor = scissor;
 
-        setupgbuffer();
+        gbuf.setupgbuffer();
 
         useshaderbyname("modelpreview");
 
@@ -1943,8 +1944,6 @@ namespace modelpreview
 
         glEnable(GL_CULL_FACE);
         glEnable(GL_DEPTH_TEST);
-
-        preparegbuffer();
     }
 
     void end()
@@ -1954,7 +1953,7 @@ namespace modelpreview
         glDisable(GL_DEPTH_TEST);
         glDisable(GL_CULL_FACE);
 
-        shademodelpreview(x, y, w, h, background, scissor);
+        gbuf.shademodelpreview(x, y, w, h, background, scissor);
 
         aspect = oldaspect;
         fovy = oldfovy;
@@ -2045,7 +2044,7 @@ void gl_drawview(void (*gamefxn)(), void(*hudfxn)(), void(*editfxn)())
     }
 
     //ambient obscurance (ambient occlusion) on geometry & models only
-    renderao();
+    gbuf.renderao();
     glerror();
 
     // render avatar after AO to avoid weird contact shadows
@@ -2059,7 +2058,7 @@ void gl_drawview(void (*gamefxn)(), void(*hudfxn)(), void(*editfxn)())
 
     glFlush();
     //global illumination
-    renderradiancehints();
+    gbuf.renderradiancehints();
     glerror();
     //lighting
     rendershadowatlas();
@@ -2073,13 +2072,13 @@ void gl_drawview(void (*gamefxn)(), void(*hudfxn)(), void(*editfxn)())
     {
         setfog(fogmat, fogbelow, 1, abovemat);
 
-        renderwaterfog(fogmat, fogbelow);
+        gbuf.renderwaterfog(fogmat, fogbelow);
 
         setfog(fogmat, fogbelow, std::clamp(fogbelow, 0.0f, 1.0f), abovemat);
     }
 
     //alpha
-    rendertransparent();
+    gbuf.rendertransparent();
     glerror();
 
     if(fogmat)
@@ -2088,7 +2087,7 @@ void gl_drawview(void (*gamefxn)(), void(*hudfxn)(), void(*editfxn)())
     }
 
     //volumetric lights
-    rendervolumetric();
+    gbuf.rendervolumetric();
     glerror();
 
     if(editmode)
@@ -2100,7 +2099,7 @@ void gl_drawview(void (*gamefxn)(), void(*hudfxn)(), void(*editfxn)())
         glerror();
         rendereditmaterials();
         glerror();
-        renderparticles();
+        gbuf.renderparticles();
         glerror();
         if(showhud)
         {

--- a/src/engine/render/rendergl.cpp
+++ b/src/engine/render/rendergl.cpp
@@ -1837,7 +1837,7 @@ void drawminimap(int yaw, int pitch, vec loc)
     rendergbuffer();
     rendershadowatlas();
 
-    shademinimap(minimapcolor.tocolor().mul(ldrscale));
+    gbuf.shademinimap(minimapcolor.tocolor().mul(ldrscale));
 
     if(minimapheight > 0 && minimapheight < minimapcenter.z + minimapradius.z)
     {
@@ -1845,7 +1845,7 @@ void drawminimap(int yaw, int pitch, vec loc)
         projmatrix.ortho(-minimapradius.x, minimapradius.x, -minimapradius.y, minimapradius.y, -zscale, zscale);
         setcamprojmatrix();
         rendergbuffer(false);
-        shademinimap();
+        gbuf.shademinimap();
     }
 
     glDisable(GL_DEPTH_TEST);

--- a/src/engine/render/rendergl.cpp
+++ b/src/engine/render/rendergl.cpp
@@ -2118,7 +2118,7 @@ void gl_drawview(void (*gamefxn)(), void(*hudfxn)(), void(*editfxn)())
         drawfogoverlay(fogmat, fogbelow, std::clamp(fogbelow, 0.0f, 1.0f), abovemat);
     }
     //antialiasing
-    doaa(setuppostfx(vieww, viewh, scalefbo), processhdr);
+    doaa(setuppostfx(vieww, viewh, scalefbo), gbuf);
     //postfx
     renderpostfx(scalefbo);
     if(scalefbo)

--- a/src/engine/render/rendergl.h
+++ b/src/engine/render/rendergl.h
@@ -23,7 +23,6 @@ extern int fov;
 extern float curfov, fovy, aspect, forceaspect;
 extern float nearplane;
 extern int farplane;
-extern bool hdrfloat;
 extern float ldrscale, ldrscaleb;
 extern int drawtex;
 extern const matrix4 viewmatrix, invviewmatrix;

--- a/src/engine/render/renderlights.cpp
+++ b/src/engine/render/renderlights.cpp
@@ -41,8 +41,7 @@ int scalew = -1,
 GLuint scalefbo[2] = { 0, 0 },
        scaletex[2] = { 0, 0 };
 int hdrclear = 0;
-GLuint refractfbo    = 0,
-       refracttex    = 0;
+
 GLenum stencilformat = 0;
 bool hdrfloat = false;
 GLuint msfbo = 0,
@@ -972,7 +971,7 @@ void viewstencil()
 
 VAR(debugrefract, 0, 0, 1);
 
-void viewrefract()
+void GBuffer::viewrefract()
 {
     int w = (debugfullscreen) ? hudw : std::min(hudw, hudh)/2, //if debugfullscreen, set to hudw/hudh size; if not, do small size
         h = (debugfullscreen) ? hudh : (w*hudh)/hudw;
@@ -4181,7 +4180,7 @@ bool debuglights()
     }
     else if(debugrefract)
     {
-        viewrefract();
+        gbuf.viewrefract();
     }
     else if(debuglightscissor)
     {

--- a/src/engine/render/renderlights.cpp
+++ b/src/engine/render/renderlights.cpp
@@ -826,8 +826,6 @@ void GBuffer::setupgbuffer()
         cleardeferredlightshaders();
     }
 
-VAR(msaadepthblit, 0, 0, 1);
-
 void GBuffer::resolvemsaadepth(int w, int h)
 {
     if(!msaasamples || msaalight)

--- a/src/engine/render/renderlights.cpp
+++ b/src/engine/render/renderlights.cpp
@@ -40,9 +40,6 @@ int scalew = -1,
 
 int hdrclear = 0;
 
-GLenum stencilformat = 0;
-bool hdrfloat = false;
-
 int spotlights       = 0,
     volumetriclights = 0,
     nospeclights     = 0;

--- a/src/engine/render/renderlights.cpp
+++ b/src/engine/render/renderlights.cpp
@@ -38,8 +38,7 @@ GBuffer gbuf;
 bool gdepthinit = false;
 int scalew = -1,
     scaleh = -1;
-GLuint scalefbo[2] = { 0, 0 },
-       scaletex[2] = { 0, 0 };
+
 int hdrclear = 0;
 
 GLenum stencilformat = 0;
@@ -150,7 +149,7 @@ void setbilateralshader(int radius, int pass, float depth)
 //for individual debug commands, see respective functions lower in the file
 VAR(debugfullscreen, 0, 0, 1);
 
-void cleanupscale()
+void GBuffer::cleanupscale()
 {
     for(int i = 0; i < 2; ++i)
     {
@@ -171,7 +170,7 @@ void cleanupscale()
     scalew = scaleh = -1;
 }
 
-void setupscale(int sw, int sh, int w, int h)
+void GBuffer::setupscale(int sw, int sh, int w, int h)
 {
     scalew = w;
     scaleh = h;
@@ -210,12 +209,12 @@ void setupscale(int sw, int sh, int w, int h)
     }
 }
 
-GLuint shouldscale()
+GLuint GBuffer::shouldscale()
 {
     return scalefbo[0];
 }
 
-void doscale(GLuint outfbo)
+void GBuffer::doscale(GLuint outfbo)
 {
     if(!scaletex[0])
     {

--- a/src/engine/render/renderlights.cpp
+++ b/src/engine/render/renderlights.cpp
@@ -35,7 +35,6 @@ int gw = -1,
 
 GBuffer gbuf;
 
-bool gdepthinit = false;
 int scalew = -1,
     scaleh = -1;
 

--- a/src/engine/render/renderlights.cpp
+++ b/src/engine/render/renderlights.cpp
@@ -3611,7 +3611,7 @@ void GBuffer::rendershadowmaps(int offset)
         {
             shadowmapping = ShadowMap_CubeMap;
             border = smfilter > 2 ? smborder2 : smborder;
-            sidemask = drawtex == Draw_TexMinimap ? 0x2F : (smsidecull ? cullfrustumsides(l.o, l.radius, sm.size, border) : 0x3F);
+            sidemask = drawtex == Draw_TexMinimap ? 0x2F : (smsidecull ? view.cullfrustumsides(l.o, l.radius, sm.size, border) : 0x3F);
         }
 
         sm.sidemask = sidemask;

--- a/src/engine/render/renderlights.cpp
+++ b/src/engine/render/renderlights.cpp
@@ -44,17 +44,6 @@ int hdrclear = 0;
 
 GLenum stencilformat = 0;
 bool hdrfloat = false;
-GLuint msfbo = 0,
-       msdepthtex   = 0,
-       mscolortex   = 0,
-       msnormaltex  = 0,
-       msglowtex    = 0,
-       msdepthrb    = 0,
-       msstencilrb  = 0,
-       mshdrfbo     = 0,
-       mshdrtex     = 0,
-       msrefractfbo = 0,
-       msrefracttex = 0;
 
 int spotlights       = 0,
     volumetriclights = 0,
@@ -402,7 +391,7 @@ void maskgbuffer(const char *mask)
     glDrawBuffers_(numbufs, drawbufs);
 }
 
-void cleanupmsbuffer()
+void GBuffer::cleanupmsbuffer()
 {
     if(msfbo)        { glDeleteFramebuffers_(1, &msfbo);        msfbo        = 0; }
     if(msdepthtex)   { glDeleteTextures(1, &msdepthtex);        msdepthtex   = 0; }
@@ -417,7 +406,7 @@ void cleanupmsbuffer()
     if(msrefracttex) { glDeleteTextures(1, &msrefracttex);      msrefracttex = 0; }
 }
 
-void bindmsdepth()
+void GBuffer::bindmsdepth()
 {
     if(gdepthformat)
     {
@@ -445,7 +434,7 @@ void bindmsdepth()
     }
 }
 
-void setupmsbuffer(int w, int h)
+void GBuffer::setupmsbuffer(int w, int h)
 {
     if(!msfbo)
     {
@@ -688,7 +677,7 @@ void GBuffer::setupgbuffer()
 
     if(msaasamples)
     {
-        setupmsbuffer(gw, gh);
+        gbuf.setupmsbuffer(gw, gh);
     }
     hdrfloat = floatformat(hdrformat);
     hdrclear = 3;
@@ -904,7 +893,7 @@ void GBuffer::resolvemsaadepth(int w, int h)
     endtimer(resolvetimer);
 }
 
-void resolvemsaacolor(int w, int h)
+void GBuffer::resolvemsaacolor(int w, int h)
 {
     if(!msaalight)
     {
@@ -3992,7 +3981,7 @@ void rendergbuffer(bool depthclear, void (*gamefxn)())
     endtimer(gcputimer);
 }
 
-void shademinimap(const vec &color)
+void GBuffer::shademinimap(const vec &color)
 {
     glerror();
 
@@ -4076,7 +4065,7 @@ void GBuffer::shademodelpreview(int x, int y, int w, int h, bool background, boo
     glerror();
 }
 
-void shadesky()
+void GBuffer::shadesky()
 {
     glBindFramebuffer_(GL_FRAMEBUFFER, msaalight ? mshdrfbo : hdrfbo);
     glViewport(0, 0, vieww, viewh);
@@ -4095,7 +4084,7 @@ void shadegbuffer()
     timer *shcputimer = begintimer("deferred shading", false),
           *shtimer = begintimer("deferred shading");
 
-    shadesky();
+    gbuf.shadesky();
 
     if(msaasamples && (msaalight || !drawtex))
     {

--- a/src/engine/render/renderlights.cpp
+++ b/src/engine/render/renderlights.cpp
@@ -253,7 +253,6 @@ VARF(msaastencil, 0, 0, 1, initwarning("MSAA setup", Init_Load, Change_Shaders))
 VARF(msaaedgedetect, 0, 1, 1, gbuf.cleanupgbuffer());                                        // multi-sample antialiasing edge detection
 VARFP(msaalineardepth, -1, -1, 3, initwarning("MSAA setup", Init_Load, Change_Shaders));// multi-sample antialiasing linear depth
 VARFP(msaatonemap, 0, 0, 1, gbuf.cleanupgbuffer());                                          // multi-sample antialiasing tone mapping
-VARF(msaatonemapblit, 0, 0, 1, gbuf.cleanupgbuffer());                                       // multi-sample antialiasing tone map bit blitting
 VAR(msaamaxsamples, 1, 0, 0);                                                           // multi-sample antialiasing maximum samples
 VAR(msaamaxdepthtexsamples, 1, 0, 0);                                                   // multi-sample antialiasing maximum depth buffer texture sample count
 VAR(msaamaxcolortexsamples, 1, 0, 0);                                                   // multi-sample antialiasing maximum color buffer texture sample count

--- a/src/engine/render/renderlights.cpp
+++ b/src/engine/render/renderlights.cpp
@@ -14,6 +14,7 @@
 #include "octarender.h"
 #include "radiancehints.h"
 #include "rendergl.h"
+#include "renderlights.h"
 #include "rendermodel.h"
 #include "rendersky.h"
 #include "rendertimers.h"
@@ -31,13 +32,9 @@
 
 int gw = -1,
     gh = -1;
-GLuint gfbo = 0,
-       gdepthtex  = 0,
-       gcolortex  = 0,
-       gnormaltex = 0,
-       gglowtex   = 0,
-       gdepthrb   = 0,
-       gstencilrb = 0;
+
+GBuffer gbuf;
+
 bool gdepthinit = false;
 int scalew = -1,
     scaleh = -1;
@@ -66,9 +63,9 @@ int spotlights       = 0,
 std::vector<vec2> msaapositions;
 
 //`g`-buffer `scale`
-VARFP(gscale, 25, 100, 100, cleanupgbuffer()); //size of g buffer, approximately correlates to g buffer linear dimensions
-VARFP(gscalecubic, 0, 0, 1, cleanupgbuffer()); //g-buffer scale cubic: use cubic interpolation for g buffer upscaling to screen output
-VARFP(gscalenearest, 0, 0, 1, cleanupgbuffer()); //g buffer nearest neighbor interpolation
+VARFP(gscale, 25, 100, 100, gbuf.cleanupgbuffer()); //size of g buffer, approximately correlates to g buffer linear dimensions
+VARFP(gscalecubic, 0, 0, 1, gbuf.cleanupgbuffer()); //g-buffer scale cubic: use cubic interpolation for g buffer upscaling to screen output
+VARFP(gscalenearest, 0, 0, 1, gbuf.cleanupgbuffer()); //g buffer nearest neighbor interpolation
 
 matrix4 eyematrix, worldmatrix, linearworldmatrix, screenmatrix;
 
@@ -208,7 +205,7 @@ void setupscale(int sw, int sh, int w, int h)
         glFramebufferTexture2D_(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE, scaletex[i], 0);
         if(!i)
         {
-            bindgdepth();
+            gbuf.bindgdepth();
         }
         if(glCheckFramebufferStatus_(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
         {
@@ -270,10 +267,10 @@ VAR(ghasstencil, 1, 0, 0);                                                      
 VARFP(msaa, 0, 0, 16, initwarning("MSAA setup", Init_Load, Change_Shaders));            // multi-sample antialiasing
 VARF(msaadepthstencil, 0, 2, 2, initwarning("MSAA setup", Init_Load, Change_Shaders));  // multi-sample antialiasing depth buffer stenciling
 VARF(msaastencil, 0, 0, 1, initwarning("MSAA setup", Init_Load, Change_Shaders));       // multi-sample antialiasing stenciling
-VARF(msaaedgedetect, 0, 1, 1, cleanupgbuffer());                                        // multi-sample antialiasing edge detection
+VARF(msaaedgedetect, 0, 1, 1, gbuf.cleanupgbuffer());                                        // multi-sample antialiasing edge detection
 VARFP(msaalineardepth, -1, -1, 3, initwarning("MSAA setup", Init_Load, Change_Shaders));// multi-sample antialiasing linear depth
-VARFP(msaatonemap, 0, 0, 1, cleanupgbuffer());                                          // multi-sample antialiasing tone mapping
-VARF(msaatonemapblit, 0, 0, 1, cleanupgbuffer());                                       // multi-sample antialiasing tone map bit blitting
+VARFP(msaatonemap, 0, 0, 1, gbuf.cleanupgbuffer());                                          // multi-sample antialiasing tone mapping
+VARF(msaatonemapblit, 0, 0, 1, gbuf.cleanupgbuffer());                                       // multi-sample antialiasing tone map bit blitting
 VAR(msaamaxsamples, 1, 0, 0);                                                           // multi-sample antialiasing maximum samples
 VAR(msaamaxdepthtexsamples, 1, 0, 0);                                                   // multi-sample antialiasing maximum depth buffer texture sample count
 VAR(msaamaxcolortexsamples, 1, 0, 0);                                                   // multi-sample antialiasing maximum color buffer texture sample count
@@ -632,7 +629,7 @@ void setupmsbuffer(int w, int h)
     }
 }
 
-void bindgdepth()
+void GBuffer::bindgdepth()
 {
     if(gdepthformat || msaalight)
     {
@@ -660,7 +657,7 @@ void bindgdepth()
     }
 }
 
-void setupgbuffer()
+void GBuffer::setupgbuffer()
 {
     //start with screen resolution
     int sw = renderw,
@@ -754,7 +751,7 @@ void setupgbuffer()
         createtexture(gnormaltex, gw, gh, nullptr, 3, 0, GL_RGBA8, GL_TEXTURE_RECTANGLE);
         createtexture(gglowtex, gw, gh, nullptr, 3, 0, hdrformat, GL_TEXTURE_RECTANGLE);
 
-        bindgdepth();
+        gbuf.bindgdepth();
         glFramebufferTexture2D_(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE, gcolortex, 0);
         glFramebufferTexture2D_(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_RECTANGLE, gnormaltex, 0);
         glFramebufferTexture2D_(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT2, GL_TEXTURE_RECTANGLE, gglowtex, 0);
@@ -790,7 +787,7 @@ void setupgbuffer()
     createtexture(hdrtex, gw, gh, nullptr, 3, 1, hdrformat, GL_TEXTURE_RECTANGLE);
 
     glFramebufferTexture2D_(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE, hdrtex, 0);
-    bindgdepth();
+    gbuf.bindgdepth();
 
     if(glCheckFramebufferStatus_(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
     {
@@ -811,7 +808,7 @@ void setupgbuffer()
         createtexture(refracttex, gw, gh, nullptr, 3, 0, GL_RGB, GL_TEXTURE_RECTANGLE);
 
         glFramebufferTexture2D_(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE, refracttex, 0);
-        bindgdepth();
+        gbuf.bindgdepth();
 
         if(glCheckFramebufferStatus_(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
         {
@@ -827,28 +824,28 @@ void setupgbuffer()
     }
 }
 
-void cleanupgbuffer()
-{
-    if(gfbo)       { glDeleteFramebuffers_(1, &gfbo);        gfbo       = 0; }
-    if(gdepthtex)  { glDeleteTextures(1, &gdepthtex);        gdepthtex  = 0; }
-    if(gcolortex)  { glDeleteTextures(1, &gcolortex);        gcolortex  = 0; }
-    if(gnormaltex) { glDeleteTextures(1, &gnormaltex);       gnormaltex = 0; }
-    if(gglowtex)   { glDeleteTextures(1, &gglowtex);         gglowtex   = 0; }
-    if(gstencilrb) { glDeleteRenderbuffers_(1, &gstencilrb); gstencilrb = 0; }
-    if(gdepthrb)   { glDeleteRenderbuffers_(1, &gdepthrb);   gdepthrb   = 0; }
-    if(hdrfbo)     { glDeleteFramebuffers_(1, &hdrfbo);      hdrfbo     = 0; }
-    if(hdrtex)     { glDeleteTextures(1, &hdrtex);           hdrtex     = 0; }
-    if(refractfbo) { glDeleteFramebuffers_(1, &refractfbo);  refractfbo = 0; }
-    if(refracttex) { glDeleteTextures(1, &refracttex);       refracttex = 0; }
-    gw = gh = -1;
-    cleanupscale();
-    cleanupmsbuffer();
-    cleardeferredlightshaders();
-}
+    void GBuffer::cleanupgbuffer()
+    {
+        if(gfbo)       { glDeleteFramebuffers_(1, &gfbo);        gfbo       = 0; }
+        if(gdepthtex)  { glDeleteTextures(1, &gdepthtex);        gdepthtex  = 0; }
+        if(gcolortex)  { glDeleteTextures(1, &gcolortex);        gcolortex  = 0; }
+        if(gnormaltex) { glDeleteTextures(1, &gnormaltex);       gnormaltex = 0; }
+        if(gglowtex)   { glDeleteTextures(1, &gglowtex);         gglowtex   = 0; }
+        if(gstencilrb) { glDeleteRenderbuffers_(1, &gstencilrb); gstencilrb = 0; }
+        if(gdepthrb)   { glDeleteRenderbuffers_(1, &gdepthrb);   gdepthrb   = 0; }
+        if(hdrfbo)     { glDeleteFramebuffers_(1, &hdrfbo);      hdrfbo     = 0; }
+        if(hdrtex)     { glDeleteTextures(1, &hdrtex);           hdrtex     = 0; }
+        if(refractfbo) { glDeleteFramebuffers_(1, &refractfbo);  refractfbo = 0; }
+        if(refracttex) { glDeleteTextures(1, &refracttex);       refracttex = 0; }
+        gw = gh = -1;
+        cleanupscale();
+        cleanupmsbuffer();
+        cleardeferredlightshaders();
+    }
 
 VAR(msaadepthblit, 0, 0, 1);
 
-void resolvemsaadepth(int w = vieww, int h = viewh)
+void GBuffer::resolvemsaadepth(int w, int h)
 {
     if(!msaasamples || msaalight)
     {
@@ -930,7 +927,7 @@ float ldrscale = 1.0f,
 
 VAR(debugdepth, 0, 0, 1); //toggles showing depth buffer onscreen
 
-void viewdepth()
+void GBuffer::viewdepth()
 {
     int w = (debugfullscreen) ? hudw : std::min(hudw, hudh)/2, //if debugfullscreen, set to hudw/hudh size; if not, do small size
         h = (debugfullscreen) ? hudh : (w*hudh)/hudw;
@@ -2122,7 +2119,7 @@ static void lightquad(float sz1, float bsx1, float bsy1, float bsx2, float bsy2,
     gle::end();
 }
 
-static void bindlighttexs(int msaapass = 0, bool transparent = false)
+void GBuffer::bindlighttexs(int msaapass, bool transparent)
 {
     if(msaapass)
     {
@@ -2591,7 +2588,7 @@ void renderlights(float bsx1, float bsy1, float bsx2, float bsy2, const uint *ti
         glDepthMask(GL_FALSE);
     }
 
-    bindlighttexs(msaapass, transparent);
+    gbuf.bindlighttexs(msaapass, transparent);
     setlightglobals(transparent);
 
     gle::defvertex(3);
@@ -2737,7 +2734,7 @@ void renderlights(float bsx1, float bsy1, float bsx2, float bsy2, const uint *ti
     }
 }
 
-void rendervolumetric()
+void GBuffer::rendervolumetric()
 {
     if(!volumetric || !volumetriclights || !volscale)
     {
@@ -3445,7 +3442,7 @@ void packlights()
     batchlights();
 }
 
-void rendercsmshadowmaps()
+void GBuffer::rendercsmshadowmaps()
 {
     if(csminoq && !debugshadowatlas && !inoq && shouldworkinoq())
     {
@@ -3564,7 +3561,7 @@ int calcshadowinfo(const extentity &e, vec &origin, float &radius, vec &spotloc,
 
 matrix4 shadowmatrix;
 
-void rendershadowmaps(int offset = 0)
+void GBuffer::rendershadowmaps(int offset)
 {
     if(!(sminoq && !debugshadowatlas && !inoq && shouldworkinoq()))
     {
@@ -3785,14 +3782,14 @@ void rendershadowatlas()
     }
 
     // sun light
-    rendercsmshadowmaps();
+    gbuf.rendercsmshadowmaps();
 
     int smoffset = shadowmaps.size();
 
     packlights();
 
     // point lights
-    rendershadowmaps(smoffset);
+    gbuf.rendershadowmaps(smoffset);
 
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
@@ -3815,15 +3812,15 @@ void workinoq()
 
         if(csminoq && !debugshadowatlas)
         {
-            rendercsmshadowmaps();
+            gbuf.rendercsmshadowmaps();
         }
         if(sminoq && !debugshadowatlas)
         {
-            rendershadowmaps();
+            gbuf.rendershadowmaps();
         }
         if(rhinoq)
         {
-            renderradiancehints();
+            gbuf.renderradiancehints();
         }
 
         inoq = false;
@@ -3833,7 +3830,7 @@ void workinoq()
 VAR(gdepthclear, 0, 1, 1);
 VAR(gcolorclear, 0, 1, 1);
 
-void preparegbuffer(bool depthclear)
+void GBuffer::preparegbuffer(bool depthclear)
 {
     glBindFramebuffer_(GL_FRAMEBUFFER, msaasamples && (msaalight || !drawtex) ? msfbo : gfbo);
     glViewport(0, 0, vieww, viewh);
@@ -3960,7 +3957,7 @@ void rendergbuffer(bool depthclear, void (*gamefxn)())
     timer *gcputimer = drawtex ? nullptr : begintimer("g-buffer", false),
           *gtimer = drawtex ? nullptr : begintimer("g-buffer");
 
-    preparegbuffer(depthclear);
+    gbuf.preparegbuffer(depthclear);
 
     if(limitsky())
     {
@@ -4013,7 +4010,7 @@ void shademinimap(const vec &color)
     glerror();
 }
 
-void shademodelpreview(int x, int y, int w, int h, bool background, bool scissor)
+void GBuffer::shademodelpreview(int x, int y, int w, int h, bool background, bool scissor)
 {
     glerror();
 
@@ -4092,7 +4089,7 @@ void shadegbuffer()
 {
     if(msaasamples && !msaalight && !drawtex)
     {
-        resolvemsaadepth();
+        gbuf.resolvemsaadepth(vieww, viewh);
     }
     glerror();
 
@@ -4134,7 +4131,7 @@ void shadegbuffer()
 void setuplights()
 {
     glerror();
-    setupgbuffer();
+    gbuf.setupgbuffer();
     if(bloomw < 0 || bloomh < 0)
     {
         setupbloom(gw, gh);
@@ -4176,7 +4173,7 @@ bool debuglights()
     }
     else if(debugdepth)
     {
-        viewdepth();
+        gbuf.viewdepth();
     }
     else if(debugstencil)
     {
@@ -4207,7 +4204,7 @@ bool debuglights()
 
 void cleanuplights()
 {
-    cleanupgbuffer();
+    gbuf.cleanupgbuffer();
     cleanupbloom();
     cleanupao();
     cleanupvolumetric();

--- a/src/engine/render/renderlights.cpp
+++ b/src/engine/render/renderlights.cpp
@@ -50,7 +50,7 @@ VARFP(gscale, 25, 100, 100, gbuf.cleanupgbuffer()); //size of g buffer, approxim
 VARFP(gscalecubic, 0, 0, 1, gbuf.cleanupgbuffer()); //g-buffer scale cubic: use cubic interpolation for g buffer upscaling to screen output
 VARFP(gscalenearest, 0, 0, 1, gbuf.cleanupgbuffer()); //g buffer nearest neighbor interpolation
 
-matrix4 eyematrix, worldmatrix, linearworldmatrix, screenmatrix;
+matrix4 worldmatrix, linearworldmatrix, screenmatrix;
 
 static Shader *bilateralshader[2] = { nullptr, nullptr };
 

--- a/src/engine/render/renderlights.cpp
+++ b/src/engine/render/renderlights.cpp
@@ -50,7 +50,7 @@ VARFP(gscale, 25, 100, 100, gbuf.cleanupgbuffer()); //size of g buffer, approxim
 VARFP(gscalecubic, 0, 0, 1, gbuf.cleanupgbuffer()); //g-buffer scale cubic: use cubic interpolation for g buffer upscaling to screen output
 VARFP(gscalenearest, 0, 0, 1, gbuf.cleanupgbuffer()); //g buffer nearest neighbor interpolation
 
-matrix4 worldmatrix, linearworldmatrix, screenmatrix;
+matrix4 worldmatrix, screenmatrix;
 
 static Shader *bilateralshader[2] = { nullptr, nullptr };
 

--- a/src/engine/render/renderlights.h
+++ b/src/engine/render/renderlights.h
@@ -103,6 +103,7 @@ class GBuffer
         GLuint scalefbo[2],
                scaletex[2];
         GLenum stencilformat;
+        matrix4 eyematrix;
 };
 
 extern GBuffer gbuf;

--- a/src/engine/render/renderlights.h
+++ b/src/engine/render/renderlights.h
@@ -105,7 +105,8 @@ class GBuffer
         GLuint scalefbo[2],
                scaletex[2];
         GLenum stencilformat;
-        matrix4 eyematrix;
+        matrix4 eyematrix,
+                linearworldmatrix;
 };
 
 extern GBuffer gbuf;

--- a/src/engine/render/renderlights.h
+++ b/src/engine/render/renderlights.h
@@ -25,17 +25,17 @@ class GBuffer
         void preparegbuffer(bool depthclear = true);
         void rendercsmshadowmaps();
         void rendershadowmaps(int offset = 0);
-        void renderao();
-        void renderradiancehints();
-        void rendertransparent();
+        void renderao();                                    //ao.cpp
+        void renderradiancehints();                         //radiancehints.cpp
+        void rendertransparent();                           //rendertransparent.cpp
         void resolvemsaadepth(int w, int h);
         void setupgbuffer();
         void bindgdepth();
         void bindlighttexs(int msaapass, bool transparent);
-        void renderparticles(int layer = 0);
+        void renderparticles(int layer = 0);                //renderparticles.cpp
         void rendervolumetric();
-        void renderwaterfog(int mat, float surface);
-        void setaavelocityparams(GLenum tmu = GL_TEXTURE0);
+        void renderwaterfog(int mat, float surface);        //water.cpp
+        void setaavelocityparams(GLenum tmu = GL_TEXTURE0); //aa.cpp
         void shademodelpreview(int x, int y, int w, int h, bool background = true, bool scissor = false);
         void viewdepth();
         //refractive

--- a/src/engine/render/renderlights.h
+++ b/src/engine/render/renderlights.h
@@ -38,6 +38,7 @@ class GBuffer
             gdepthinit   = false;
             hdrfloat     = false;
             msaadepthblit= false;
+            msaatonemapblit = false;
         }
         //main g-buffers
         void cleanupgbuffer();
@@ -77,6 +78,7 @@ class GBuffer
         bool gdepthinit;
         bool hdrfloat;
         bool msaadepthblit; //no way to change this outside constructor atm
+        bool msaatonemapblit;
 
         //main g-buffers
         GLuint gfbo,

--- a/src/engine/render/renderlights.h
+++ b/src/engine/render/renderlights.h
@@ -30,6 +30,10 @@ class GBuffer
             msrefracttex = 0;
             refractfbo   = 0;
             refracttex   = 0;
+            scalefbo[0]  = 0;
+            scalefbo[1]  = 0;
+            scaletex[0]  = 0;
+            scaletex[1]  = 0;
         }
         //main g-buffers
         void cleanupgbuffer();
@@ -58,9 +62,14 @@ class GBuffer
         //refractive
         void processhdr(GLuint outfbo, int aa);
         void viewrefract();
+        void doscale(GLuint outfbo = 0);
+        void setupscale(int sw, int sh, int w, int h);
+        GLuint shouldscale();
 
     private:
         void bindmsdepth();
+        void cleanupscale();
+
         //main g-buffers
         GLuint gfbo,
                gdepthtex,
@@ -84,6 +93,9 @@ class GBuffer
         //refractive g-buffers
         GLuint refractfbo,
                refracttex;
+        //rescaling g-buffers
+        GLuint scalefbo[2],
+               scaletex[2];
 
 };
 

--- a/src/engine/render/renderlights.h
+++ b/src/engine/render/renderlights.h
@@ -1,0 +1,52 @@
+#ifndef RENDERLIGHTS_H_
+#define RENDERLIGHTS_H_
+
+/* gbuffer: a singleton object used to store the graphics buffers
+ * (as OpenGL uints) and the functions which act upon the g-buffers.
+ */
+class GBuffer
+{
+    public:
+        GBuffer()
+        {
+            gfbo = 0;
+            gdepthtex = 0;
+            gcolortex = 0;
+            gnormaltex = 0;
+            gglowtex = 0;
+            gdepthrb = 0;
+            gstencilrb = 0;
+        }
+
+        void cleanupgbuffer();
+        void preparegbuffer(bool depthclear = true);
+        void rendercsmshadowmaps();
+        void rendershadowmaps(int offset = 0);
+        void renderao();
+        void renderradiancehints();
+        void rendertransparent();
+        void resolvemsaadepth(int w, int h);
+        void setupgbuffer();
+        void bindgdepth();
+        void bindlighttexs(int msaapass, bool transparent);
+        void renderparticles(int layer = 0);
+        void rendervolumetric();
+        void renderwaterfog(int mat, float surface);
+        void setaavelocityparams(GLenum tmu = GL_TEXTURE0);
+        void shademodelpreview(int x, int y, int w, int h, bool background = true, bool scissor = false);
+        void viewdepth();
+
+    private:
+        GLuint gfbo,
+           gdepthtex,
+           gcolortex,
+           gnormaltex,
+           gglowtex,
+           gdepthrb,
+           gstencilrb;
+
+};
+
+extern GBuffer gbuf;
+
+#endif

--- a/src/engine/render/renderlights.h
+++ b/src/engine/render/renderlights.h
@@ -10,15 +10,26 @@ class GBuffer
         GBuffer()
         {
             //set all of the textures to 0/null
-            gfbo       = 0;
-            gdepthtex  = 0;
-            gcolortex  = 0;
-            gnormaltex = 0;
-            gglowtex   = 0;
-            gdepthrb   = 0;
-            gstencilrb = 0;
-            refractfbo = 0;
-            refracttex = 0;
+            gfbo         = 0;
+            gdepthtex    = 0;
+            gcolortex    = 0;
+            gnormaltex   = 0;
+            gglowtex     = 0;
+            gdepthrb     = 0;
+            gstencilrb   = 0;
+            msfbo        = 0;
+            msdepthtex   = 0;
+            mscolortex   = 0;
+            msnormaltex  = 0;
+            msglowtex    = 0;
+            msdepthrb    = 0;
+            msstencilrb  = 0;
+            mshdrfbo     = 0;
+            mshdrtex     = 0;
+            msrefractfbo = 0;
+            msrefracttex = 0;
+            refractfbo   = 0;
+            refracttex   = 0;
         }
         //main g-buffers
         void cleanupgbuffer();
@@ -38,11 +49,18 @@ class GBuffer
         void setaavelocityparams(GLenum tmu = GL_TEXTURE0); //aa.cpp
         void shademodelpreview(int x, int y, int w, int h, bool background = true, bool scissor = false);
         void viewdepth();
+        //multisample antialiasing specific buffers
+        void setupmsbuffer(int w, int h);
+        void cleanupmsbuffer();
+        void resolvemsaacolor(int w, int h);
+        void shademinimap(const vec &color = vec(-1, -1, -1));
+        void shadesky();
         //refractive
         void processhdr(GLuint outfbo, int aa);
         void viewrefract();
 
     private:
+        void bindmsdepth();
         //main g-buffers
         GLuint gfbo,
                gdepthtex,
@@ -51,6 +69,18 @@ class GBuffer
                gglowtex,
                gdepthrb,
                gstencilrb;
+        //multisample antialiasing g-buffers
+        GLuint msfbo = 0,
+               msdepthtex   = 0,
+               mscolortex   = 0,
+               msnormaltex  = 0,
+               msglowtex    = 0,
+               msdepthrb    = 0,
+               msstencilrb  = 0,
+               mshdrfbo     = 0,
+               mshdrtex     = 0,
+               msrefractfbo = 0,
+               msrefracttex = 0;
         //refractive g-buffers
         GLuint refractfbo,
                refracttex;

--- a/src/engine/render/renderlights.h
+++ b/src/engine/render/renderlights.h
@@ -9,6 +9,7 @@ class GBuffer
     public:
         GBuffer()
         {
+            //set all of the textures to 0/null
             gfbo = 0;
             gdepthtex = 0;
             gcolortex = 0;
@@ -16,8 +17,10 @@ class GBuffer
             gglowtex = 0;
             gdepthrb = 0;
             gstencilrb = 0;
+            refractfbo = 0;
+            refracttex = 0;
         }
-
+        //main g-buffers
         void cleanupgbuffer();
         void preparegbuffer(bool depthclear = true);
         void rendercsmshadowmaps();
@@ -35,8 +38,12 @@ class GBuffer
         void setaavelocityparams(GLenum tmu = GL_TEXTURE0);
         void shademodelpreview(int x, int y, int w, int h, bool background = true, bool scissor = false);
         void viewdepth();
+        //refractive
+        void processhdr(GLuint outfbo, int aa);
+        void viewrefract();
 
     private:
+        //main g-buffers
         GLuint gfbo,
            gdepthtex,
            gcolortex,
@@ -44,6 +51,9 @@ class GBuffer
            gglowtex,
            gdepthrb,
            gstencilrb;
+        //refractive g-buffers
+        GLuint refractfbo,
+               refracttex;
 
 };
 

--- a/src/engine/render/renderlights.h
+++ b/src/engine/render/renderlights.h
@@ -55,7 +55,6 @@ class GBuffer
         void viewdepth();
         //multisample antialiasing specific buffers
         void setupmsbuffer(int w, int h);
-        void cleanupmsbuffer();
         void resolvemsaacolor(int w, int h);
         void shademinimap(const vec &color = vec(-1, -1, -1));
         void shadesky();
@@ -69,6 +68,7 @@ class GBuffer
     private:
         void bindmsdepth();
         void cleanupscale();
+        void cleanupmsbuffer();
 
         //main g-buffers
         GLuint gfbo,

--- a/src/engine/render/renderlights.h
+++ b/src/engine/render/renderlights.h
@@ -10,12 +10,12 @@ class GBuffer
         GBuffer()
         {
             //set all of the textures to 0/null
-            gfbo = 0;
-            gdepthtex = 0;
-            gcolortex = 0;
+            gfbo       = 0;
+            gdepthtex  = 0;
+            gcolortex  = 0;
             gnormaltex = 0;
-            gglowtex = 0;
-            gdepthrb = 0;
+            gglowtex   = 0;
+            gdepthrb   = 0;
             gstencilrb = 0;
             refractfbo = 0;
             refracttex = 0;

--- a/src/engine/render/renderlights.h
+++ b/src/engine/render/renderlights.h
@@ -37,6 +37,7 @@ class GBuffer
             stencilformat= 0;
             gdepthinit   = false;
             hdrfloat     = false;
+            msaadepthblit= false;
         }
         //main g-buffers
         void cleanupgbuffer();
@@ -75,6 +76,7 @@ class GBuffer
 
         bool gdepthinit;
         bool hdrfloat;
+        bool msaadepthblit; //no way to change this outside constructor atm
 
         //main g-buffers
         GLuint gfbo,

--- a/src/engine/render/renderlights.h
+++ b/src/engine/render/renderlights.h
@@ -45,12 +45,12 @@ class GBuffer
     private:
         //main g-buffers
         GLuint gfbo,
-           gdepthtex,
-           gcolortex,
-           gnormaltex,
-           gglowtex,
-           gdepthrb,
-           gstencilrb;
+               gdepthtex,
+               gcolortex,
+               gnormaltex,
+               gglowtex,
+               gdepthrb,
+               gstencilrb;
         //refractive g-buffers
         GLuint refractfbo,
                refracttex;

--- a/src/engine/render/renderlights.h
+++ b/src/engine/render/renderlights.h
@@ -34,6 +34,7 @@ class GBuffer
             scalefbo[1]  = 0;
             scaletex[0]  = 0;
             scaletex[1]  = 0;
+            gdepthinit   = false;
         }
         //main g-buffers
         void cleanupgbuffer();
@@ -69,6 +70,8 @@ class GBuffer
         void bindmsdepth();
         void cleanupscale();
         void cleanupmsbuffer();
+
+        bool gdepthinit;
 
         //main g-buffers
         GLuint gfbo,

--- a/src/engine/render/renderlights.h
+++ b/src/engine/render/renderlights.h
@@ -34,7 +34,9 @@ class GBuffer
             scalefbo[1]  = 0;
             scaletex[0]  = 0;
             scaletex[1]  = 0;
+            stencilformat= 0;
             gdepthinit   = false;
+            hdrfloat     = false;
         }
         //main g-buffers
         void cleanupgbuffer();
@@ -72,6 +74,7 @@ class GBuffer
         void cleanupmsbuffer();
 
         bool gdepthinit;
+        bool hdrfloat;
 
         //main g-buffers
         GLuint gfbo,
@@ -99,7 +102,7 @@ class GBuffer
         //rescaling g-buffers
         GLuint scalefbo[2],
                scaletex[2];
-
+        GLenum stencilformat;
 };
 
 extern GBuffer gbuf;

--- a/src/engine/render/renderlights.h
+++ b/src/engine/render/renderlights.h
@@ -82,17 +82,17 @@ class GBuffer
                gdepthrb,
                gstencilrb;
         //multisample antialiasing g-buffers
-        GLuint msfbo = 0,
-               msdepthtex   = 0,
-               mscolortex   = 0,
-               msnormaltex  = 0,
-               msglowtex    = 0,
-               msdepthrb    = 0,
-               msstencilrb  = 0,
-               mshdrfbo     = 0,
-               mshdrtex     = 0,
-               msrefractfbo = 0,
-               msrefracttex = 0;
+        GLuint msfbo,
+               msdepthtex,
+               mscolortex,
+               msnormaltex,
+               msglowtex,
+               msdepthrb,
+               msstencilrb,
+               mshdrfbo,
+               mshdrtex,
+               msrefractfbo,
+               msrefracttex;
         //refractive g-buffers
         GLuint refractfbo,
                refracttex;

--- a/src/engine/render/renderparticles.cpp
+++ b/src/engine/render/renderparticles.cpp
@@ -12,6 +12,7 @@
 
 #include "engine.h"
 
+#include "renderlights.h"
 #include "rendergl.h"
 #include "renderparticles.h"
 #include "renderva.h"
@@ -1387,7 +1388,7 @@ void debugparticles()
     pophudmatrix();
 }
 
-void renderparticles(int layer)
+void GBuffer::renderparticles(int layer)
 {
     canstep = layer != ParticleLayer_Under;
 

--- a/src/engine/render/renderparticles.h
+++ b/src/engine/render/renderparticles.h
@@ -17,7 +17,6 @@ extern void clearparticles();
 extern void clearparticleemitters();
 extern void seedparticles();
 extern void debugparticles();
-extern void renderparticles(int layer = ParticleLayer_All);
 extern void cleanupparticles();
 
 extern void regular_particle_splash(int type, int num, int fade, const vec &p, int color = 0xFFFFFF, float size = 1.0f, int radius = 150, int gravity = 2, int delay = 0);

--- a/src/engine/render/shader.cpp
+++ b/src/engine/render/shader.cpp
@@ -4,6 +4,7 @@
 
 #include "octarender.h"
 #include "rendergl.h"
+#include "renderlights.h"
 #include "rendermodel.h"
 #include "rendertimers.h"
 #include "renderwindow.h"
@@ -1633,7 +1634,7 @@ GLuint setuppostfx(int w, int h, GLuint outfbo)
     glBindFramebuffer_(GL_FRAMEBUFFER, postfxfb);
     int tex = allocatepostfxtex(0);
     glFramebufferTexture2D_(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE, postfxtexs[tex].id, 0);
-    bindgdepth();
+    gbuf.bindgdepth();
 
     postfxbinds[0] = tex;
     postfxtexs[tex].used = 0;

--- a/src/engine/render/water.cpp
+++ b/src/engine/render/water.cpp
@@ -12,6 +12,7 @@
 
 #include "octarender.h"
 #include "rendergl.h"
+#include "renderlights.h"
 #include "water.h"
 
 #include "interface/control.h"
@@ -120,7 +121,7 @@ void rendercaustics(float surface, float syl, float syr)
     gle::end();
 }
 
-void renderwaterfog(int mat, float surface)
+void GBuffer::renderwaterfog(int mat, float surface)
 {
     glDepthFunc(GL_NOTEQUAL);
     glDepthMask(GL_FALSE);

--- a/src/engine/render/water.h
+++ b/src/engine/render/water.h
@@ -36,7 +36,6 @@ extern float getwaterfallrefract(int mat);
 extern void renderwater();
 extern void renderwaterfalls();
 extern void loadcaustics(bool force = false);
-extern void renderwaterfog(int mat, float blend);
 extern void preloadwatershaders(bool force = false);
 
 #endif


### PR DESCRIPTION
This pull request, similarly to #231, moves many global variables and functions, largely in `renderlights.cpp`, into a singleton object in `renderlights.h`. This hides all of the OpenGL buffer object references (`GLuint`) as being private within the new `GBuffer` object, and presents a function-only interface to be used by other parts of the engine.

The GBuffers are the OpenGL buffers (textures) that contain the intermediate data used to create the scene. The various g-buffers are accessed by many files which implement specific rendering behavior (e.g. water, ao, particles, etc.) and are eventually what are used to render the scene to the screen.
