### PR TITLE
Remove texture.h header.

### DIFF
--- a/test/libprimis.h
+++ b/test/libprimis.h
@@ -4,6 +4,5 @@
 #include "../src/libprimis-headers/cube.h"
 #include "../src/libprimis-headers/iengine.h"
 #include "../src/libprimis-headers/consts.h"
-#include "../src/libprimis-headers/texture.h"
 
 #endif


### PR DESCRIPTION
The texture.h header does not exist anymore, so it needed to be removed.