### PR TITLE
transforming every vec2 into vec2<float> and GenericVec2<T> into vec2<T> 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ src/tess_server
 *.srctrlprj
 # Files auto-produced by VSCode.
 .vscode/
+.ionide/
 # Documentation files in the docs folder.
 docs

--- a/src/engine/interface/ui.cpp
+++ b/src/engine/interface/ui.cpp
@@ -68,7 +68,7 @@ namespace UI
         gle::attribf(x,   y+h); gle::attribf(tx,    ty+th);
     }
 
-    static void quad(float x, float y, float w, float h, const vec2 tc[4])
+    static void quad(float x, float y, float w, float h, const vec2<float> tc[4])
     {
         gle::defvertex(2);
         gle::deftexcoord0();
@@ -794,7 +794,7 @@ namespace UI
         uint *contents, *onshow, *onhide;
         bool allowinput, eschide, abovehud;
         float px, py, pw, ph;
-        vec2 sscale, soffset;
+        vec2<float> sscale, soffset;
 
         Window(const char *name, const char *contents, const char *onshow, const char *onhide) :
             name(newstring(name)),
@@ -950,8 +950,8 @@ namespace UI
 
         void calcscissor(float x1, float y1, float x2, float y2, int &sx1, int &sy1, int &sx2, int &sy2, bool clip = true)
         {
-            vec2 s1 = vec2(x1, y2).mul(sscale).add(soffset),
-                 s2 = vec2(x2, y1).mul(sscale).add(soffset);
+            vec2<float> s1 = vec2(x1, y2).mul(sscale).add(soffset),
+                        s2 = vec2(x2, y1).mul(sscale).add(soffset);
             sx1 = static_cast<int>(std::floor(s1.x*hudw + 0.5f));
             sy1 = static_cast<int>(std::floor(s1.y*hudh + 0.5f));
             sx2 = static_cast<int>(std::floor(s2.x*hudw + 0.5f));
@@ -2381,7 +2381,7 @@ namespace UI
 
     struct Triangle : Shape
     {
-        vec2 a, b, c;
+        vec2<float> a, b, c;
 
         void setup(const Color &color_, float w = 0, float h = 0, int angle = 0, int type_ = SOLID)
         {
@@ -2390,16 +2390,16 @@ namespace UI
             c = vec2(w/2, h/3);
             if(angle)
             {
-                vec2 rot = sincosmod360(-angle);
+                vec2<float> rot = sincosmod360(-angle);
                 a.rotate_around_z(rot);
                 b.rotate_around_z(rot);
                 c.rotate_around_z(rot);
             }
-            vec2 bbmin = vec2(a).min(b).min(c);
+            vec2<float> bbmin = vec2(a).min(b).min(c);
             a.sub(bbmin);
             b.sub(bbmin);
             c.sub(bbmin);
-            vec2 bbmax = vec2(a).max(b).max(c);
+            vec2<float> bbmax = vec2(a).max(b).max(c);
 
             Shape::setup(color_, type_, bbmax.x, bbmax.y);
         }
@@ -2486,7 +2486,7 @@ namespace UI
 
             float r = radius <= 0 ? std::min(w, h)/2 : radius;
             color.init();
-            vec2 center(sx + r, sy + r);
+            vec2<float> center(sx + r, sy + r);
             if(type == OUTLINE)
             {
                 gle::begin(GL_LINE_LOOP);
@@ -2501,7 +2501,7 @@ namespace UI
                 gle::attribf(center.x + r, center.y);
                 for(int angle = 360/15; angle < 360; angle += 360/15)
                 {
-                    vec2 p = vec2(sincos360[angle]).mul(r).add(center);
+                    vec2<float> p = vec2(sincos360[angle]).mul(r).add(center);
                     gle::attrib(p);
                     gle::attrib(p);
                 }
@@ -4260,7 +4260,7 @@ namespace UI
             changedraw(Change_Shader | Change_Color);
 
             SETSHADER(hudrgb);
-            vec2 tc[4] = { vec2(0, 0), vec2(1, 0), vec2(1, 1), vec2(0, 1) };
+            vec2<float> tc[4] = { vec2(0, 0), vec2(1, 0), vec2(1, 1), vec2(0, 1) };
             int xoff = vslot.offset.x,
                 yoff = vslot.offset.y;
             if(vslot.rotation)

--- a/src/engine/model/animmodel.h
+++ b/src/engine/model/animmodel.h
@@ -276,9 +276,9 @@ class animmodel : public model
                         vec e1 = vec(verts[t.vert[1]].pos).sub(e0),
                             e2 = vec(verts[t.vert[2]].pos).sub(e0);
 
-                        const vec2 &tc0 = tcverts[t.vert[0]].tc,
-                                   &tc1 = tcverts[t.vert[1]].tc,
-                                   &tc2 = tcverts[t.vert[2]].tc;
+                        const vec2<float> &tc0 = tcverts[t.vert[0]].tc,
+                                          &tc1 = tcverts[t.vert[1]].tc,
+                                          &tc2 = tcverts[t.vert[2]].tc;
                         float u1 = tc1.x - tc0.x,
                               v1 = tc1.y - tc0.y,
                               u2 = tc2.x - tc0.x,

--- a/src/engine/model/md5.h
+++ b/src/engine/model/md5.h
@@ -15,7 +15,7 @@ struct md5weight
 
 struct md5vert
 {
-    vec2 tc;
+    vec2<float> tc;
     ushort start, count;
 };
 

--- a/src/engine/model/obj.cpp
+++ b/src/engine/model/obj.cpp
@@ -190,7 +190,7 @@ bool obj::objmeshgroup::load(const char *filename, float smooth)
                         v.norm = vkey.z < 0 ? vec(0, 0, 0) : attrib[2][vkey.z];
                         v.norm = vec(v.norm.z, -v.norm.x, v.norm.y);
                         tcvert &tcv = tcverts.add();
-                        tcv.tc = vkey.y < 0 ? vec2(0, 0) : vec2(attrib[1][vkey.y].x, 1-attrib[1][vkey.y].y);
+                        tcv.tc = vkey.y < 0 ? vec2(0.f, 0.f) : vec2(attrib[1][vkey.y].x, 1-attrib[1][vkey.y].y);
                     }
                     if(v0 < 0)
                     {

--- a/src/engine/model/skelmodel.h
+++ b/src/engine/model/skelmodel.h
@@ -26,7 +26,7 @@ struct skelmodel : animmodel
     struct vert
     {
         vec pos, norm;
-        vec2 tc;
+        vec2<float> tc;
         quat tangent;
         int blend, interpindex;
     };
@@ -34,14 +34,14 @@ struct skelmodel : animmodel
     struct vvert
     {
         vec pos;
-        GenericVec2<half> tc;
+        vec2<half> tc;
         squat tangent;
     };
 
     struct vvertg
     {
         vec4<half> pos;
-        GenericVec2<half> tc;
+        vec2<half> tc;
         squat tangent;
     };
 

--- a/src/engine/model/vertmodel.h
+++ b/src/engine/model/vertmodel.h
@@ -9,14 +9,14 @@ struct vertmodel : animmodel
     struct vvert
     {
         vec pos;
-        GenericVec2<half> tc;
+        vec2<half> tc;
         squat tangent;
     };
 
     struct vvertg
     {
         vec4<half> pos;
-        GenericVec2<half> tc;
+        vec2<half> tc;
         squat tangent;
     };
 

--- a/src/engine/model/vertmodel.h
+++ b/src/engine/model/vertmodel.h
@@ -22,7 +22,7 @@ struct vertmodel : animmodel
 
     struct tcvert
     {
-        vec2 tc;
+        vec2<float> tc;
     };
 
     struct tri

--- a/src/engine/render/aa.cpp
+++ b/src/engine/render/aa.cpp
@@ -415,24 +415,24 @@ namespace //internal functions incl. AA implementations
         smaasearchdatainited = true;
     }
 
-    vec2 areaunderortho(const vec2 &p1, const vec2 &p2, float x)
+    vec2<float> areaunderortho(const vec2<float> &p1, const vec2<float> &p2, float x)
     {
-        vec2 d(p2.x - p1.x, p2.y - p1.y);
+        vec2<float> d(p2.x - p1.x, p2.y - p1.y);
         float y1 = p1.y + (x - p1.x)*d.y/d.x,
               y2 = p1.y + (x+1 - p1.x)*d.y/d.x;
         if((x < p1.x || x >= p2.x) && (x+1 <= p1.x || x+1 > p2.x))
         {
-            return vec2(0, 0);
+            return vec2(0.f, 0.f);
         }
         if((y1 < 0) == (y2 < 0) || std::fabs(y1) < 1e-4f || std::fabs(y2) < 1e-4f)
         {
             float a = (y1 + y2) / 2;
-            return a < 0.0f ? vec2(-a, 0) : vec2(0, a);
+            return a < 0.0f ? vec2(-a, 0.f) : vec2(0.f, a);
         }
         x = -p1.y*d.x/d.y + p1.x;
         float a1 = x > p1.x ? y1*std::fmod(x, 1.0f)/2 : 0,
               a2 = x < p2.x ? y2*(1-std::fmod(x, 1.0f))/2 : 0;
-        vec2 a(std::fabs(a1), std::fabs(a2));
+        vec2<float> a(std::fabs(a1), std::fabs(a2));
         if((a.x > a.y ? a1 : -a2) >= 0)
         {
             std::swap(a.x, a.y);
@@ -446,21 +446,21 @@ namespace //internal functions incl. AA implementations
         {0, 1}, {3, 1}, {0, 4}, {3, 4}, {1, 1}, {4, 1}, {1, 4}, {4, 4}
     };
 
-    vec2 areaortho(float p1x, float p1y, float p2x, float p2y, float left)
+    vec2<float> areaortho(float p1x, float p1y, float p2x, float p2y, float left)
     {
         return areaunderortho(vec2(p1x, p1y), vec2(p2x, p2y), left);
     }
 
-    void smootharea(float d, vec2 &a1, vec2 &a2)
+    void smootharea(float d, vec2<float> &a1, vec2<float> &a2)
     {
-        vec2 b1(sqrtf(a1.x*2)*0.5f, sqrtf(a1.y*2)*0.5f),
-             b2(sqrtf(a2.x*2)*0.5f, sqrtf(a2.y*2)*0.5f);
+        vec2<float> b1(sqrtf(a1.x*2)*0.5f, sqrtf(a1.y*2)*0.5f),
+                    b2(sqrtf(a2.x*2)*0.5f, sqrtf(a2.y*2)*0.5f);
         float p = std::clamp(d / 32.0f, 0.0f, 1.0f);
         a1.lerp(b1, a1, p);
         a2.lerp(b2, a2, p);
     }
 
-    vec2 areaortho(int pattern, float left, float right, float offset)
+    vec2<float> areaortho(int pattern, float left, float right, float offset)
     {
         float d = left + right + 1,
               o1 = offset + 0.5f,
@@ -469,33 +469,33 @@ namespace //internal functions incl. AA implementations
         {
             case 0:
             {
-                return vec2(0, 0);
+                return vec2(0.f, 0.f);
             }
             case 1:
             {
-                return left <= right ? areaortho(0, o2, d/2, 0, left) : vec2(0, 0);
+                return left <= right ? areaortho(0, o2, d/2, 0, left) : vec2(0.f, 0.f);
             }
             case 2:
             {
-                return left >= right ? areaortho(d/2, 0, d, o2, left) : vec2(0, 0);
+                return left >= right ? areaortho(d/2, 0, d, o2, left) : vec2(0.f, 0.f);
             }
             case 3:
             {
-                vec2 a1 = areaortho(0, o2, d/2, 0, left), a2 = areaortho(d/2, 0, d, o2, left);
+                vec2<float> a1 = areaortho(0, o2, d/2, 0, left), a2 = areaortho(d/2, 0, d, o2, left);
                 smootharea(d, a1, a2);
                 return a1.add(a2);
             }
             case 4:
             {
-                return left <= right ? areaortho(0, o1, d/2, 0, left) : vec2(0, 0);
+                return left <= right ? areaortho(0, o1, d/2, 0, left) : vec2(0.f, 0.f);
             }
             case 5:
             {
-                return vec2(0, 0);
+                return vec2(0.f, 0.f);
             }
             case 6:
             {
-                vec2 a = areaortho(0, o1, d, o2, left);
+                vec2<float> a = areaortho(0, o1, d, o2, left);
                 if(std::fabs(offset) > 0)
                 {
                     a.avg(areaortho(0, o1, d/2, 0, left).add(areaortho(d/2, 0, d, o2, left)));
@@ -508,11 +508,11 @@ namespace //internal functions incl. AA implementations
             }
             case 8:
             {
-                return left >= right ? areaortho(d/2, 0, d, o1, left) : vec2(0, 0);
+                return left >= right ? areaortho(d/2, 0, d, o1, left) : vec2(0.f, 0.f);
             }
             case 9:
             {
-                vec2 a = areaortho(0, o2, d, o1, left);
+                vec2<float> a = areaortho(0, o2, d, o1, left);
                 if(std::fabs(offset) > 0)
                 {
                     a.avg(areaortho(0, o2, d/2, 0, left).add(areaortho(d/2, 0, d, o1, left)));
@@ -521,7 +521,7 @@ namespace //internal functions incl. AA implementations
             }
             case 10:
             {
-                return vec2(0, 0);
+                return vec2(0.f, 0.f);
             }
             case 11:
             {
@@ -529,8 +529,8 @@ namespace //internal functions incl. AA implementations
             }
             case 12:
             {
-                vec2 a1 = areaortho(0, o1, d/2, 0, left),
-                     a2 = areaortho(d/2, 0, d, o1, left);
+                vec2<float> a1 = areaortho(0, o1, d/2, 0, left),
+                            a2 = areaortho(d/2, 0, d, o1, left);
                 smootharea(d, a1, a2);
                 return a1.add(a2);
             }
@@ -544,15 +544,15 @@ namespace //internal functions incl. AA implementations
             }
             case 15:
             {
-                return vec2(0, 0);
+                return vec2(0.f, 0.f);
             }
         }
-        return vec2(0, 0);
+        return vec2(0.f, 0.f);
     }
 
-    float areaunderdiag(const vec2 &p1, const vec2 &p2, const vec2 &p)
+    float areaunderdiag(const vec2<float> &p1, const vec2<float> &p2, const vec2<float> &p)
     {
-        vec2 d(p2.y - p1.y, p1.x - p2.x);
+        vec2<float> d(p2.y - p1.y, p1.x - p2.x);
         float dp = d.dot(vec2(p1).sub(p));
         if(!d.x)
         {
@@ -625,9 +625,9 @@ namespace //internal functions incl. AA implementations
         return 1;
     }
 
-    vec2 areadiag(const vec2 &p1, const vec2 &p2, float left)
+    vec2<float> areadiag(const vec2<float> &p1, const vec2<float> &p2, float left)
     {
-        return vec2(1 - areaunderdiag(p1, p2, vec2(1, 0).add(left)), areaunderdiag(p1, p2, vec2(1, 1).add(left)));
+        return vec2(1 - areaunderdiag(p1, p2, vec2(1.f, 0.f).add(left)), areaunderdiag(p1, p2, vec2(1.f, 1.f).add(left)));
     }
 
     constexpr int edgesdiag[][2] =
@@ -636,10 +636,10 @@ namespace //internal functions incl. AA implementations
         {0, 1}, {1, 1}, {0, 3}, {1, 3}, {2, 1}, {3, 1}, {2, 3}, {3, 3}
     };
 
-    vec2 areadiag(float p1x, float p1y, float p2x, float p2y, float d, float left, const vec2 &offset, int pattern)
+    vec2<float> areadiag(float p1x, float p1y, float p2x, float p2y, float d, float left, const vec2<float> &offset, int pattern)
     {
-        vec2 p1(p1x, p1y),
-             p2(p2x+d, p2y+d);
+        vec2<float> p1(p1x, p1y),
+                    p2(p2x+d, p2y+d);
         if(edgesdiag[pattern][0])
         {
             p1.add(offset);
@@ -651,12 +651,12 @@ namespace //internal functions incl. AA implementations
         return areadiag(p1, p2, left);
     }
 
-    vec2 areadiag2(float p1x, float p1y, float p2x, float p2y, float p3x, float p3y, float p4x, float p4y, float d, float left, const vec2 &offset, int pattern)
+    vec2<float> areadiag2(float p1x, float p1y, float p2x, float p2y, float p3x, float p3y, float p4x, float p4y, float d, float left, const vec2<float> &offset, int pattern)
     {
-        vec2 p1(p1x, p1y),
-             p2(p2x+d, p2y+d),
-             p3(p3x, p3y),
-             p4(p4x+d, p4y+d);
+        vec2<float> p1(p1x, p1y),
+                    p2(p2x+d, p2y+d),
+                    p3(p3x, p3y),
+                    p4(p4x+d, p4y+d);
         if(edgesdiag[pattern][0])
         {
             p1.add(offset);
@@ -670,7 +670,7 @@ namespace //internal functions incl. AA implementations
         return areadiag(p1, p2, left).avg(areadiag(p3, p4, left));
     }
 
-    vec2 areadiag(int pattern, float left, float right, const vec2 &offset)
+    vec2<float> areadiag(int pattern, float left, float right, const vec2<float> &offset)
     {
         float d = left + right + 1;
         switch(pattern)
@@ -692,7 +692,7 @@ namespace //internal functions incl. AA implementations
             case 14: return areadiag2(1, 1, 1, 1, 1, 1, 1, 0, d, left, offset, pattern);
             case 15: return areadiag2(1, 1, 1, 1, 1, 0, 1, 0, d, left, offset, pattern);
         }
-        return vec2(0, 0);
+        return vec2(0.f, 0.f);
     }
 
     constexpr float offsetsortho[] = { 0.0f, -0.25f, 0.25f, -0.125f, 0.125f, -0.375f, 0.375f };
@@ -723,7 +723,7 @@ namespace //internal functions incl. AA implementations
                 {
                     for(int x = 0; x < 16; ++x)
                     {
-                        vec2 a = areaortho(pattern, x*x, y*y, offsetsortho[offset]);
+                        vec2<float> a = areaortho(pattern, x*x, y*y, offsetsortho[offset]);
                         dst[0] = static_cast<uchar>(255*a.x);
                         dst[1] = static_cast<uchar>(255*a.y);
                         dst += 2;
@@ -743,7 +743,7 @@ namespace //internal functions incl. AA implementations
                 {
                     for(int x = 0; x < 20; ++x)
                     {
-                        vec2 a = areadiag(pattern, x, y, vec2(offsetsdiag[offset][0], offsetsdiag[offset][1]));
+                        vec2<float> a = areadiag(pattern, x, y, vec2(offsetsdiag[offset][0], offsetsdiag[offset][1]));
                         dst[0] = static_cast<uchar>(255*a.x);
                         dst[1] = static_cast<uchar>(255*a.y);
                         dst += 2;
@@ -1068,7 +1068,7 @@ void GBuffer::setaavelocityparams(GLenum tmu)
 
     matrix4 reproject;
     reproject.muld(tqaaframe ? tqaaprevscreenmatrix : screenmatrix, worldmatrix);
-    vec2 jitter = tqaaframe&1 ? vec2(0.5f, 0.5f) : vec2(-0.5f, -0.5f);
+    vec2<float> jitter = tqaaframe&1 ? vec2(0.5f, 0.5f) : vec2(-0.5f, -0.5f);
     if(multisampledaa())
     {
         jitter.x *= 0.5f;
@@ -1111,7 +1111,7 @@ void jitteraa()
     nojittermatrix = projmatrix;
     if(!drawtex && tqaa)
     {
-        vec2 jitter = tqaaframe&1 ? vec2(0.25f, 0.25f) : vec2(-0.25f, -0.25f);
+        vec2<float> jitter = tqaaframe&1 ? vec2(0.25f, 0.25f) : vec2(-0.25f, -0.25f);
         if(multisampledaa())
         {
             jitter.x *= 0.5f;

--- a/src/engine/render/csm.cpp
+++ b/src/engine/render/csm.cpp
@@ -217,7 +217,7 @@ void cascadedshadowmap::getprojmatrix()
         int border = smfilter > 2 ? smborder2 : smborder;
         const float pradius = std::ceil(radius * csmpradiustweak),
                     step    = (2*pradius) / (sm.size - 2*border);
-        vec2 offset = vec2(tc).sub(pradius).div(step);
+        vec2<float> offset = vec2(tc).sub(pradius).div(step);
         offset.x = std::floor(offset.x);
         offset.y = std::floor(offset.y);
         split.center = vec(vec2(offset).mul(step).add(pradius), -0.5f*(minz + maxz));

--- a/src/engine/render/grass.cpp
+++ b/src/engine/render/grass.cpp
@@ -48,7 +48,7 @@ namespace //internal functionality not seen by other files
     {
         vec pos;
         vec4<uchar> color;
-        vec2 tc;
+        vec2<float> tc;
     };
 
     std::vector<grassvert> grassverts;

--- a/src/engine/render/hud.cpp
+++ b/src/engine/render/hud.cpp
@@ -65,9 +65,9 @@ namespace
                 m.translate(0, offset, 0);
                 m.scale(size*scale);
 
-                gle::attrib(m.transform(vec2(1, 1)));
-                gle::attrib(m.transform(vec2(-1, 1)));
-                gle::attrib(m.transform(vec2(0, 0)));
+                gle::attrib(m.transform(vec2(1.f, 1.f)));
+                gle::attrib(m.transform(vec2(-1.f, 1.f)));
+                gle::attrib(m.transform(vec2(0.f, 0.f)));
 
                 // fade in log space so short blips don't disappear too quickly
                 scale -= static_cast<float>(curtime)/damagecompassfade;

--- a/src/engine/render/octarender.cpp
+++ b/src/engine/render/octarender.cpp
@@ -1237,7 +1237,7 @@ namespace
             return vec(0, 0, 1);
         }
         norm--;
-        const vec2 &yaw = sincos360[norm%360],
+        const vec2<float> &yaw = sincos360[norm%360],
                    &pitch = sincos360[norm/360+270];
         return vec(-yaw.y*pitch.x, yaw.x*pitch.x, pitch.y);
     }

--- a/src/engine/render/radiancehints.cpp
+++ b/src/engine/render/radiancehints.cpp
@@ -961,7 +961,7 @@ void reflectiveshadowmap::getprojmatrix()
     model.transform(c, tc);
     const float pradius = std::ceil((radius + gidist) * rsmpradiustweak),
                 step = (2*pradius) / rsmsize;
-    vec2 tcoff = vec2(tc).sub(pradius).div(step);
+    vec2<float> tcoff = vec2(tc).sub(pradius).div(step);
     tcoff.x = std::floor(tcoff.x);
     tcoff.y = std::floor(tcoff.y);
     center = vec(vec2(tcoff).mul(step).add(pradius), -0.5f*(minz + maxz));

--- a/src/engine/render/rendergl.cpp
+++ b/src/engine/render/rendergl.cpp
@@ -1488,7 +1488,7 @@ static void setupscreenquad()
     {
         glGenBuffers_(1, &screenquadvbo);
         gle::bindvbo(screenquadvbo);
-        vec2 verts[4] = { vec2(1, -1), vec2(-1, -1), vec2(1, 1), vec2(-1, 1) };
+        vec2<float> verts[4] = { vec2(1.ff, -1.f), vec2(-1.f, -1.f), vec2(1.f, 1.f), vec2(-1.f, 1.f) };
         glBufferData_(GL_ARRAY_BUFFER, sizeof(verts), verts, GL_STATIC_DRAW);
         gle::clearvbo();
     }
@@ -1508,7 +1508,7 @@ void screenquad()
     setupscreenquad();
     gle::bindvbo(screenquadvbo);
     gle::enablevertex();
-    gle::vertexpointer(sizeof(vec2), (const vec2 *)0, GL_FLOAT, 2);
+    gle::vertexpointer(sizeof(vec2<float>), (const vec2<float> *)0, GL_FLOAT, 2);
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     gle::disablevertex();
     gle::clearvbo();

--- a/src/engine/render/renderlights.cpp
+++ b/src/engine/render/renderlights.cpp
@@ -50,7 +50,7 @@ int hdrclear = 0;
 int spotlights       = 0,
     volumetriclights = 0,
     nospeclights     = 0;
-std::vector<vec2> msaapositions;
+std::vector<vec2<float>> msaapositions;
 
 //`g`-buffer `scale`
 VARFP(gscale, 25, 100, 100, gbuf.cleanupgbuffer()); //size of g buffer, approximately correlates to g buffer linear dimensions
@@ -2184,7 +2184,7 @@ static void setlightglobals(bool transparent = false)
         }
         else
         {
-            GLOBALPARAM(aoscale, aotex[2] ? vec2(1, 1) : vec2(static_cast<float>(aow)/vieww, static_cast<float>(aoh)/viewh));
+            GLOBALPARAM(aoscale, aotex[2] ? vec2(1.f, 1.f) : vec2(static_cast<float>(aow)/vieww, static_cast<float>(aoh)/viewh));
             GLOBALPARAMF(aoparams, aomin, 1.0f-aomin, aosunmin, 1.0f-aosunmin);
         }
     }
@@ -2228,7 +2228,7 @@ static LocalShaderParam lightpos("lightpos"),
                         shadowparams("shadowparams"),
                         shadowoffset("shadowoffset");
 static vec4<float> lightposv[8], lightcolorv[8], spotparamsv[8], shadowparamsv[8];
-static vec2 shadowoffsetv[8];
+static vec2<float> shadowoffsetv[8];
 
 static void setlightparams(int i, const lightinfo &l)
 {

--- a/src/engine/render/renderlights.h
+++ b/src/engine/render/renderlights.h
@@ -248,7 +248,7 @@ extern int calcspherersmsplits(const vec &center, float radius);
 
 inline bool sphereinsidespot(const vec &dir, int spot, const vec &center, float radius)
 {
-    const vec2 &sc = sincos360[spot];
+    const vec2<float> &sc = sincos360[spot];
     float cdist = dir.dot(center), cradius = radius + sc.y*cdist;
     return sc.x*sc.x*(center.dot(center) - cdist*cdist) <= cradius*cradius;
 }
@@ -262,7 +262,7 @@ extern matrix4 worldmatrix, screenmatrix;
 
 extern int gw, gh, gdepthformat, ghasstencil;
 extern int msaasamples, msaalight;
-extern std::vector<vec2> msaapositions;
+extern std::vector<vec2<float>> msaapositions;
 
 extern bool inoq;
 extern int rhinoq;

--- a/src/engine/render/renderparticles.cpp
+++ b/src/engine/render/renderparticles.cpp
@@ -204,7 +204,7 @@ struct partvert
 {
     vec pos;     //x,y,z of particle
     vec4<float> color; //r,g,b,a color
-    vec2 tc;     //texture coordinate
+    vec2<float> tc;     //texture coordinate
 };
 
 static constexpr float collideradius = 8.0f;
@@ -536,7 +536,7 @@ class meterrenderer : public listrenderer
                 gle::begin(GL_TRIANGLE_STRIP);
                 for(int k = 0; k < 10; ++k)
                 {
-                    const vec2 &sc = sincos360[k*(180/(10-1))];
+                    const vec2<float> &sc = sincos360[k*(180/(10-1))];
                     float c = (0.5f + 0.1f)*sc.y,
                           s = 0.5f - (0.5f + 0.1f)*sc.x;
                     gle::attrib(m.transform(vec2(-c, s)));
@@ -555,7 +555,7 @@ class meterrenderer : public listrenderer
             gle::begin(GL_TRIANGLE_STRIP);
             for(int k = 0; k < 10; ++k)
             {
-                const vec2 &sc = sincos360[k*(180/(10-1))];
+                const vec2<float> &sc = sincos360[k*(180/(10-1))];
                 float c = 0.5f*sc.y,
                       s = 0.5f - 0.5f*sc.x;
                 gle::attrib(m.transform(vec2(left + c, s)));
@@ -569,7 +569,7 @@ class meterrenderer : public listrenderer
                 gle::begin(GL_TRIANGLE_FAN);
                 for(int k = 0; k < 10; ++k)
                 {
-                    const vec2 &sc = sincos360[k*(180/(10-1))];
+                    const vec2<float> &sc = sincos360[k*(180/(10-1))];
                     float c = (0.5f + 0.1f)*sc.y,
                           s = 0.5f - (0.5f + 0.1f)*sc.x;
                     gle::attrib(m.transform(vec2(left + c, s)));
@@ -581,7 +581,7 @@ class meterrenderer : public listrenderer
             gle::begin(GL_TRIANGLE_STRIP);
             for(int k = 0; k < 10; ++k)
             {
-                const vec2 &sc = sincos360[k*(180/(10-1))];
+                const vec2<float> &sc = sincos360[k*(180/(10-1))];
                 float c = 0.5f*sc.y,
                       s = 0.5f - 0.5f*sc.x;
                 gle::attrib(m.transform(vec2(-c, s)));
@@ -694,10 +694,10 @@ void genrotpos(const vec &o, const vec &d, float size, int grav, int ts, partver
 
 //==================================================================== ROTCOEFFS
 #define ROTCOEFFS(n) { \
-    vec2(-1,  1).rotate_around_z(n*2*M_PI/32.0f), \
-    vec2( 1,  1).rotate_around_z(n*2*M_PI/32.0f), \
-    vec2( 1, -1).rotate_around_z(n*2*M_PI/32.0f), \
-    vec2(-1, -1).rotate_around_z(n*2*M_PI/32.0f) \
+    vec2(-1.f,  1.f).rotate_around_z(n*2*M_PI/32.0f), \
+    vec2( 1.f,  1.f).rotate_around_z(n*2*M_PI/32.0f), \
+    vec2( 1.f, -1.f).rotate_around_z(n*2*M_PI/32.0f), \
+    vec2(-1.f, -1.f).rotate_around_z(n*2*M_PI/32.0f) \
 }
 static const vec2 rotcoeffs[32][4] =
 {

--- a/src/engine/render/renderparticles.cpp
+++ b/src/engine/render/renderparticles.cpp
@@ -699,7 +699,7 @@ void genrotpos(const vec &o, const vec &d, float size, int grav, int ts, partver
     vec2( 1.f, -1.f).rotate_around_z(n*2*M_PI/32.0f), \
     vec2(-1.f, -1.f).rotate_around_z(n*2*M_PI/32.0f) \
 }
-static const vec2 rotcoeffs[32][4] =
+static const vec2<float> rotcoeffs[32][4] =
 {
     ROTCOEFFS(0),  ROTCOEFFS(1),  ROTCOEFFS(2),  ROTCOEFFS(3),  ROTCOEFFS(4),  ROTCOEFFS(5),  ROTCOEFFS(6),  ROTCOEFFS(7),
     ROTCOEFFS(8),  ROTCOEFFS(9),  ROTCOEFFS(10), ROTCOEFFS(11), ROTCOEFFS(12), ROTCOEFFS(13), ROTCOEFFS(14), ROTCOEFFS(15),
@@ -898,10 +898,10 @@ struct varenderer : partrenderer
                       v1 = v1c, \
                       v2 = v2c; \
                 body; \
-                vs[0].tc = vec2(u1, v1); \
-                vs[1].tc = vec2(u2, v1); \
-                vs[2].tc = vec2(u2, v2); \
-                vs[3].tc = vec2(u1, v2); \
+                vs[0].tc = vec2<float>(u1, v1); \
+                vs[1].tc = vec2<float>(u2, v1); \
+                vs[2].tc = vec2<float>(u2, v2); \
+                vs[3].tc = vec2<float>(u1, v2); \
             }
             if(type&PT_RND4)
             {
@@ -1742,7 +1742,7 @@ static void regularshape(int type, int radius, int color, int dir, int num, int 
         vec to, from;
         if(dir < 12)
         {
-            const vec2 &sc = sincos360[randomint(360)];
+            const vec2<float> &sc = sincos360[randomint(360)];
             to[dir%3] = sc.y*radius;
             to[(dir+1)%3] = sc.x*radius;
             to[(dir+2)%3] = 0.0;

--- a/src/engine/render/renderva.cpp
+++ b/src/engine/render/renderva.cpp
@@ -643,7 +643,7 @@ namespace
         GLuint textures[7];
         Slot *slot, *texgenslot;
         VSlot *vslot, *texgenvslot;
-        vec2 texgenscroll;
+        vec2<float> texgenscroll;
         int texgenorient, texgenmillis;
 
         renderstate() : colormask(true), depthmask(true), alphaing(0), vbuf(0), vattribs(false),
@@ -1070,7 +1070,7 @@ namespace
                 const texrotation &r = texrotations[vslot.rotation];
                 float xs = r.flipx ? -tex->xs : tex->xs,
                       ys = r.flipy ? -tex->ys : tex->ys;
-                vec2 scroll(vslot.scroll);
+                vec2<float> scroll(vslot.scroll);
                 if(r.swapxy)
                 {
                     std::swap(scroll.x, scroll.y);

--- a/src/engine/render/stain.cpp
+++ b/src/engine/render/stain.cpp
@@ -34,7 +34,7 @@ struct stainvert
 {
     vec pos;
     vec4<uchar> color;
-    vec2 tc;
+    vec2<float> tc;
 };
 
 struct staininfo

--- a/src/engine/render/texture.h
+++ b/src/engine/render/texture.h
@@ -476,7 +476,7 @@ struct GlobalShaderParam
         setf(v.x, v.y, v.z, w);
     }
 
-    void set(const vec2 &v, float z = 0, float w = 0)
+    void set(const vec2<float> &v, float z = 0, float w = 0)
     {
         setf(v.x, v.y, z, w);
     }
@@ -658,7 +658,7 @@ struct LocalShaderParam
         setf(v.x, v.y, v.z, w);
     }
 
-    void set(const vec2 &v, float z = 0, float w = 0)
+    void set(const vec2<float> &v, float z = 0, float w = 0)
     {
         setf(v.x, v.y, z, w);
     }
@@ -691,7 +691,7 @@ struct LocalShaderParam
         }
     }
 
-    void setv(const vec2 *v, int n = 1)
+    void setv(const vec2<float> *v, int n = 1)
     {
         ShaderParamBinding *b = resolve();
         if(b)

--- a/src/engine/world/bih.cpp
+++ b/src/engine/world/bih.cpp
@@ -88,9 +88,9 @@ bool BIH::triintersect(const mesh &m, int tidx, const vec &mo, const vec &mray, 
     float invdet = 1/det;
     if(m.flags&Mesh_Alpha && (mode&Ray_Shadow)==Ray_Shadow && (m.tex->alphamask || loadalphamask(m.tex)))
     {
-        vec2 at = m.gettc(t.vert[0]),
-             bt = m.gettc(t.vert[1]).sub(at).mul(v*invdet),
-             ct = m.gettc(t.vert[2]).sub(at).mul(w*invdet);
+        vec2<float> at = m.gettc(t.vert[0]),
+                    bt = m.gettc(t.vert[1]).sub(at).mul(v*invdet),
+                    ct = m.gettc(t.vert[2]).sub(at).mul(w*invdet);
         at.add(bt).add(ct);
         int si = std::clamp(static_cast<int>(m.tex->xs * at.x), 0, m.tex->xs-1),
             ti = std::clamp(static_cast<int>(m.tex->ys * at.y), 0, m.tex->ys-1);
@@ -498,19 +498,19 @@ bool mmintersect(const extentity &e, const vec &o, const vec &ray, float maxdist
     //reorientation of rotated mmodels
     if(yaw != 0)
     {
-        const vec2 &rot = sincosmod360(-yaw);
+        const vec2<float> &rot = sincosmod360(-yaw);
         mo.rotate_around_z(rot);
         mray.rotate_around_z(rot);
     }
     if(pitch != 0)
     {
-        const vec2 &rot = sincosmod360(-pitch);
+        const vec2<float> &rot = sincosmod360(-pitch);
         mo.rotate_around_x(rot);
         mray.rotate_around_x(rot);
     }
     if(roll != 0)
     {
-        const vec2 &rot = sincosmod360(roll);
+        const vec2<float> &rot = sincosmod360(roll);
         mo.rotate_around_y(rot);
         mray.rotate_around_y(rot);
     }

--- a/src/engine/world/bih.h
+++ b/src/engine/world/bih.h
@@ -72,9 +72,9 @@ class BIH
             {
                 return *reinterpret_cast<const vec *>(pos + i*posstride);
             }
-            vec2 gettc(int i) const
+            vec2<float> gettc(int i) const
             {
-                return *reinterpret_cast<const vec2 *>(tc + i*tcstride);
+                return *reinterpret_cast<const vec2<float> *>(tc + i*tcstride);
             }
         };
 

--- a/src/engine/world/octaedit.cpp
+++ b/src/engine/world/octaedit.cpp
@@ -1909,7 +1909,7 @@ void rendertexturepanel(int w, int h)
                       sy = std::min(1.0f, tex->ys/static_cast<float>(tex->xs));
                 int x = w*1800/h-s-50,
                     r = s;
-                vec2 tc[4] = { vec2(0, 0), vec2(1, 0), vec2(1, 1), vec2(0, 1) };
+                vec2<float> tc[4] = { vec2(0.f, 0.f), vec2(1.f, 0.f), vec2(1.f, 1.f), vec2(0.f, 1.f) };
                 float xoff = vslot.offset.x,
                       yoff = vslot.offset.y;
                 if(vslot.rotation)

--- a/src/engine/world/physics.cpp
+++ b/src/engine/world/physics.cpp
@@ -526,13 +526,13 @@ static bool fuzzycollideellipse(physent *d, const vec &dir, float cutoff, const 
             }
             case 2:
             {
-                vec2 ln(mdlvol.orient.transform(entvol.center().sub(mdlvol.o)));
+                vec2<float> ln(mdlvol.orient.transform(entvol.center().sub(mdlvol.o)));
                 float r = ln.magnitude();
                 if(r < 1e-6f)
                 {
                     continue;
                 }
-                vec2 lw = vec2(ln.x*radius.y, ln.y*radius.x).normalize();
+                vec2<float> lw = vec2(ln.x*radius.y, ln.y*radius.x).normalize();
                 w = mdlvol.orient.transposedtransform(lw);
                 dist = -vec2(ln.x*radius.x, ln.y*radius.y).dot(lw)/r;
                 break;

--- a/src/shared/geom.cpp
+++ b/src/shared/geom.cpp
@@ -258,7 +258,7 @@ int polyclip(const vec *in, int numin, const vec &dir, float below, float above,
 
 //LUT used for fast angle calculations ingame
 //range 0 to 720 degrees to allow using offsets without needing slow modulus operators
-extern const vec2 sincos360[721] =
+extern const vec2<float> sincos360[721] =
 {
     vec2(1.00000000, 0.00000000), vec2(0.99984770, 0.01745241), vec2(0.99939083, 0.03489950), vec2(0.99862953, 0.05233596), vec2(0.99756405, 0.06975647), vec2(0.99619470, 0.08715574), // 0
     vec2(0.99452190, 0.10452846), vec2(0.99254615, 0.12186934), vec2(0.99026807, 0.13917310), vec2(0.98768834, 0.15643447), vec2(0.98480775, 0.17364818), vec2(0.98162718, 0.19080900), // 6

--- a/src/shared/glemu.cpp
+++ b/src/shared/glemu.cpp
@@ -500,7 +500,7 @@ namespace gle
     void vertexf(float x, float y, float z, float w) { glVertexAttrib4f_(Attribute_Vertex, x, y, z, w); }
     void vertex(const vec &v) { glVertexAttrib3fv_(Attribute_Vertex, v.v); }
     void vertex(const vec &v, float w) { glVertexAttrib4f_(Attribute_Vertex, v.x, v.y, v.z, w); }
-    void vertex(const vec2 &v) { glVertexAttrib2fv_(Attribute_Vertex, v.v); }
+    void vertex(const vec2<float> &v) { glVertexAttrib2fv_(Attribute_Vertex, v.v); }
     void vertex(const vec4<float> &v) { glVertexAttrib4fv_(Attribute_Vertex, v.v); }
 
     void colorf(float x) { glVertexAttrib1f_(Attribute_Color, x); }
@@ -510,7 +510,7 @@ namespace gle
 
     void color(const vec &v) { glVertexAttrib3fv_(Attribute_Color, v.v); }
     void color(const vec &v, float w) { glVertexAttrib4f_(Attribute_Color, v.x, v.y, v.z, w); }
-    void color(const vec2 &v) { glVertexAttrib2fv_(Attribute_Color, v.v); }
+    void color(const vec2<float> &v) { glVertexAttrib2fv_(Attribute_Color, v.v); }
     void color(const vec4<float> &v) { glVertexAttrib4fv_(Attribute_Color, v.v); }
 
     void colorub(uchar x, uchar y, uchar z, uchar w) { glVertexAttrib4Nub_(Attribute_Color, x, y, z, w); }
@@ -523,7 +523,7 @@ namespace gle
 
     void texcoord0(const vec &v) { glVertexAttrib3fv_(Attribute_TexCoord0, v.v); }
     void texcoord0(const vec &v, float w) { glVertexAttrib4f_(Attribute_TexCoord0, v.x, v.y, v.z, w); }
-    void texcoord0(const vec2 &v) { glVertexAttrib2fv_(Attribute_TexCoord0, v.v); }
+    void texcoord0(const vec2<float> &v) { glVertexAttrib2fv_(Attribute_TexCoord0, v.v); }
     void texcoord0(const vec4<float> &v) { glVertexAttrib4fv_(Attribute_TexCoord0, v.v); }
     void texcoord1f(float x) { glVertexAttrib1f_(Attribute_TexCoord1, x); }
     void texcoord1f(float x, float y) { glVertexAttrib2f_(Attribute_TexCoord1, x, y); }
@@ -531,7 +531,7 @@ namespace gle
     void texcoord1f(float x, float y, float z, float w) { glVertexAttrib4f_(Attribute_TexCoord1, x, y, z, w); }
     void texcoord1(const vec &v) { glVertexAttrib3fv_(Attribute_TexCoord1, v.v); }
     void texcoord1(const vec &v, float w) { glVertexAttrib4f_(Attribute_TexCoord1, v.x, v.y, v.z, w); }
-    void texcoord1(const vec2 &v) { glVertexAttrib2fv_(Attribute_TexCoord1, v.v); }
+    void texcoord1(const vec2<float> &v) { glVertexAttrib2fv_(Attribute_TexCoord1, v.v); }
     void texcoord1(const vec4<float> &v) { glVertexAttrib4fv_(Attribute_TexCoord1, v.v); }
     void normal(float x, float y, float z) { glVertexAttrib4f_(Attribute_Normal, x, y, z, 0.0f); }
     void normal(const vec &v) { glVertexAttrib4f_(Attribute_Normal, v.x, v.y, v.z, 0.0f); }
@@ -658,7 +658,7 @@ namespace gle
 
     void attrib(const vec &v) { attribf(v.x, v.y, v.z); }
     void attrib(const vec &v, float w) { attribf(v.x, v.y, v.z, w); }
-    void attrib(const vec2 &v) { attribf(v.x, v.y); }
+    void attrib(const vec2<float> &v) { attribf(v.x, v.y); }
     void attrib(const vec4<float> &v) { attribf(v.x, v.y, v.z, v.w); }
     void attrib(const ivec &v) { attribi(v.x, v.y, v.z); }
     void attrib(const ivec &v, int w) { attribi(v.x, v.y, v.z, w); }


### PR DESCRIPTION
This is a paired effort alongside https://github.com/project-imprimis/libprimis-headers/pull/14 to make a common `vec2<T>`  struct for the whole engine.

There still exists the `ivec` struct which has deliberately left untouched for the time being, even though one could "theoretically" exchange it with `vec2<int>`