### PR TITLE
Remove addcommand redundant arguments.

### DIFF
--- a/src/engine/interface/console.cpp
+++ b/src/engine/interface/console.cpp
@@ -1201,7 +1201,7 @@ void writecompletions(stream *f)
 void initconsolecmds()
 {
     addcommand("fullconsole", reinterpret_cast<identfun>(fullconsole), "iN$", Id_Command);
-    addcommand("toggleconsole", reinterpret_cast<identfun>(toggleconsole), "", Id_Command);
+    addcommand("toggleconsole", reinterpret_cast<identfun>(toggleconsole));
 
     static auto conskipcmd = [] (int *n)
     {
@@ -1216,7 +1216,7 @@ void initconsolecmds()
     };
     addcommand("miniconskip", reinterpret_cast<identfun>(+miniconskipcmd), "i", Id_Command);
 
-    addcommand("clearconsole", reinterpret_cast<identfun>(clearconsole), "", Id_Command);
+    addcommand("clearconsole", reinterpret_cast<identfun>(clearconsole));
     addcommand("keymap", reinterpret_cast<identfun>(keymap), "is", Id_Command);
 
     static auto bind = [] (char *key, char *action)
@@ -1277,25 +1277,25 @@ void initconsolecmds()
     {
         ENUMERATE(keyms, KeyM, km, km.clear(KeyM::Action_Default));
     };
-    addcommand("clearbinds", reinterpret_cast<identfun>(+clearbinds), "", Id_Command);
+    addcommand("clearbinds", reinterpret_cast<identfun>(+clearbinds));
 
     static auto clearspecbinds = [] ()
     {
         ENUMERATE(keyms, KeyM, km, km.clear(KeyM::Action_Spectator));
     };
-    addcommand("clearspecbinds", reinterpret_cast<identfun>(+clearspecbinds), "", Id_Command);
+    addcommand("clearspecbinds", reinterpret_cast<identfun>(+clearspecbinds));
 
     static auto cleareditbinds = [] ()
     {
         ENUMERATE(keyms, KeyM, km, km.clear(KeyM::Action_Editing));
     };
-    addcommand("cleareditbinds", reinterpret_cast<identfun>(+cleareditbinds), "", Id_Command);
+    addcommand("cleareditbinds", reinterpret_cast<identfun>(+cleareditbinds));
 
     static auto clearallbinds = [] ()
     {
         ENUMERATE(keyms, KeyM, km, km.clear());
     };
-    addcommand("clearallbinds", reinterpret_cast<identfun>(+clearallbinds), "", Id_Command);
+    addcommand("clearallbinds", reinterpret_cast<identfun>(+clearallbinds));
     addcommand("inputcommand", reinterpret_cast<identfun>(inputcommand), "ssss", Id_Command);
     addcommand("saycommand", reinterpret_cast<identfun>(saycommand), "C", Id_Command);
     addcommand("history", reinterpret_cast<identfun>(historycmd), "i", Id_Command);

--- a/src/engine/interface/cubestd.cpp
+++ b/src/engine/interface/cubestd.cpp
@@ -1411,7 +1411,7 @@ void initcontrolcmds()
     addcommand("escape", reinterpret_cast<identfun>(escapecmd), "s", Id_Command);
     addcommand("unescape", reinterpret_cast<identfun>(unescapecmd), "s", Id_Command);
     addcommand("writecfg", reinterpret_cast<identfun>(writecfg), "s", Id_Command);
-    addcommand("changedvars", reinterpret_cast<identfun>(changedvars), "", Id_Command);
+    addcommand("changedvars", reinterpret_cast<identfun>(changedvars));
     addcommand("doargs", reinterpret_cast<identfun>(doargs), "e", Id_DoArgs);
 
     addcommand("if", reinterpret_cast<identfun>(+[] (tagval *cond, uint *t, uint *f) { executeret(getbool(*cond) ? t : f, *commandret); }), "tee", Id_If);

--- a/src/engine/interface/menus.cpp
+++ b/src/engine/interface/menus.cpp
@@ -150,6 +150,6 @@ void clearmainmenu()
 
 void initmenuscmds()
 {
-    addcommand("applychanges", reinterpret_cast<identfun>(applychanges), "", Id_Command);
+    addcommand("applychanges", reinterpret_cast<identfun>(applychanges));
     addcommand("pendingchanges", reinterpret_cast<identfun>(pendingchanges), "b", Id_Command); 
 }

--- a/src/engine/interface/sound.cpp
+++ b/src/engine/interface/sound.cpp
@@ -1085,7 +1085,7 @@ void initsoundcmds()
 
     addcommand("music", reinterpret_cast<identfun>(startmusic), "ss", Id_Command);
     addcommand("playsound", reinterpret_cast<identfun>(playsound), "i", Id_Command); //i: the index of the sound to be played
-    addcommand("resetsound", reinterpret_cast<identfun>(resetsound), "", Id_Command); //stop all sounds and re-play background music
+    addcommand("resetsound", reinterpret_cast<identfun>(resetsound)); //stop all sounds and re-play background music
 
     static auto registersound = [] (char *name, int *vol)
     {
@@ -1131,9 +1131,9 @@ void initsoundcmds()
     addcommand("mapsound", reinterpret_cast<identfun>(+mapsound), "sii", Id_Command);
     addcommand("altsound", reinterpret_cast<identfun>(+altsound), "si", Id_Command);
     addcommand("altmapsound", reinterpret_cast<identfun>(+altmapsound), "si", Id_Command);
-    addcommand("numsounds", reinterpret_cast<identfun>(+numsounds), "", Id_Command);
-    addcommand("nummapsounds", reinterpret_cast<identfun>(+nummapsounds), "", Id_Command);
-    addcommand("soundreset", reinterpret_cast<identfun>(+soundreset), "", Id_Command);
-    addcommand("mapsoundreset", reinterpret_cast<identfun>(+mapsoundreset), "", Id_Command);
+    addcommand("numsounds", reinterpret_cast<identfun>(+numsounds));
+    addcommand("nummapsounds", reinterpret_cast<identfun>(+nummapsounds));
+    addcommand("soundreset", reinterpret_cast<identfun>(+soundreset));
+    addcommand("mapsoundreset", reinterpret_cast<identfun>(+mapsoundreset));
 
 }

--- a/src/engine/interface/textedit.cpp
+++ b/src/engine/interface/textedit.cpp
@@ -1083,18 +1083,18 @@ static const char * pastebuffer = "#pastebuffer";
 void inittextcmds()
 {
     addcommand("textinit", reinterpret_cast<identfun>(textinit), "sss", Id_Command); // loads into named editor if no file assigned and editor has been rendered
-    addcommand("textlist", reinterpret_cast<identfun>(textlist), "", Id_Command);
-    addcommand("textshow", reinterpret_cast<identfun>(+[] () { if(!textfocus || identflags&Idf_Overridden) return; /* @DEBUG return the start of the buffer*/ EditLine line; line.combinelines(textfocus->lines); result(line.text); line.clear();; }), "", Id_Command);
+    addcommand("textlist", reinterpret_cast<identfun>(textlist));
+    addcommand("textshow", reinterpret_cast<identfun>(+[] () { if(!textfocus || identflags&Idf_Overridden) return; /* @DEBUG return the start of the buffer*/ EditLine line; line.combinelines(textfocus->lines); result(line.text); line.clear();; }));
     addcommand("textfocus", reinterpret_cast<identfun>(textfocuscmd), "si", Id_Command);
-    addcommand("textprev", reinterpret_cast<identfun>(+[] () { if(!textfocus || identflags&Idf_Overridden) return; editors.insert(0, textfocus); editors.pop();; }), "", Id_Command);; // return to the previous editor
+    addcommand("textprev", reinterpret_cast<identfun>(+[] () { if(!textfocus || identflags&Idf_Overridden) return; editors.insert(0, textfocus); editors.pop();; }));; // return to the previous editor
     addcommand("textmode", reinterpret_cast<identfun>(+[] (int *m) { if(!textfocus || identflags&Idf_Overridden) return; /* (1= keep while focused, 2= keep while used in gui, 3= keep forever (i.e. until mode changes)) topmost editor, return current setting if no args*/ if(*m) { textfocus->mode = *m; } else { intret(textfocus->mode); }; }), "i", Id_Command);
     addcommand("textsave", reinterpret_cast<identfun>(textsave), "s", Id_Command);
     addcommand("textload", reinterpret_cast<identfun>(textload), "s", Id_Command);
-    addcommand("textcopy", reinterpret_cast<identfun>(+[] () { if(!textfocus || identflags&Idf_Overridden) return; Editor *b = useeditor(pastebuffer, Editor_Forever, false); textfocus->copyselectionto(b);; }), "", Id_Command);;
-    addcommand("textpaste", reinterpret_cast<identfun>(+[] () { if(!textfocus || identflags&Idf_Overridden) return; Editor *b = useeditor(pastebuffer, Editor_Forever, false); textfocus->insertallfrom(b);; }), "", Id_Command);;
+    addcommand("textcopy", reinterpret_cast<identfun>(+[] () { if(!textfocus || identflags&Idf_Overridden) return; Editor *b = useeditor(pastebuffer, Editor_Forever, false); textfocus->copyselectionto(b);; }));;
+    addcommand("textpaste", reinterpret_cast<identfun>(+[] () { if(!textfocus || identflags&Idf_Overridden) return; Editor *b = useeditor(pastebuffer, Editor_Forever, false); textfocus->insertallfrom(b);; }));;
     addcommand("textmark", reinterpret_cast<identfun>(+[] (int *m) { if(!textfocus || identflags&Idf_Overridden) return; /* (1=mark, 2=unmark), return current mark setting if no args*/ if(*m) { textfocus->mark(*m==1); } else { intret(textfocus->region() ? 1 : 2); }; }), "i", Id_Command);;
-    addcommand("textselectall", reinterpret_cast<identfun>(+[] () { if(!textfocus || identflags&Idf_Overridden) return; textfocus->selectall();; }), "", Id_Command);;
-    addcommand("textclear", reinterpret_cast<identfun>(+[] () { if(!textfocus || identflags&Idf_Overridden) return; textfocus->clear();; }), "", Id_Command);;
-    addcommand("textcurrentline", reinterpret_cast<identfun>(+[] () { if(!textfocus || identflags&Idf_Overridden) return; result(textfocus->currentline().text);; }), "", Id_Command);;
+    addcommand("textselectall", reinterpret_cast<identfun>(+[] () { if(!textfocus || identflags&Idf_Overridden) return; textfocus->selectall();; }));;
+    addcommand("textclear", reinterpret_cast<identfun>(+[] () { if(!textfocus || identflags&Idf_Overridden) return; textfocus->clear();; }));;
+    addcommand("textcurrentline", reinterpret_cast<identfun>(+[] () { if(!textfocus || identflags&Idf_Overridden) return; result(textfocus->currentline().text);; }));;
     addcommand("textexec", reinterpret_cast<identfun>(+[] (int *selected) { if(!textfocus || identflags&Idf_Overridden) return; /* execute script commands from the buffer (0=all, 1=selected region only)*/ char *script = *selected ? textfocus->selectiontostring() : textfocus->tostring(); execute(script); delete[] script;; }), "i", Id_Command);
 }

--- a/src/engine/interface/ui.cpp
+++ b/src/engine/interface/ui.cpp
@@ -4617,8 +4617,8 @@ namespace UI
         addcommand("uitarget", reinterpret_cast<identfun>(+[] (float *minw, float *minh, uint *children) { BUILD(Target, o, o->setup(*minw, *minh), children); }), "ffe", Id_Command);
         addcommand("uiclip", reinterpret_cast<identfun>(+[] (float *clipw, float *cliph, uint *children) { BUILD(Clipper, o, o->setup(*clipw, *cliph), children); }), "ffe", Id_Command);
         addcommand("uiscroll", reinterpret_cast<identfun>(+[] (float *clipw, float *cliph, uint *children) { BUILD(Scroller, o, o->setup(*clipw, *cliph), children); }), "ffe", Id_Command);
-        addcommand("uihscrolloffset", reinterpret_cast<identfun>(+[] () { { if(buildparent && buildparent->istype<Scroller>()) { Scroller *scroller = static_cast<Scroller *>(buildparent); floatret(scroller->offsetx); } }; }), "", Id_Command);
-        addcommand("uivscrolloffset", reinterpret_cast<identfun>(+[] () { { if(buildparent && buildparent->istype<Scroller>()) { Scroller *scroller = static_cast<Scroller *>(buildparent); floatret(scroller->offsety); } }; }), "", Id_Command);
+        addcommand("uihscrolloffset", reinterpret_cast<identfun>(+[] () { { if(buildparent && buildparent->istype<Scroller>()) { Scroller *scroller = static_cast<Scroller *>(buildparent); floatret(scroller->offsetx); } }; }));
+        addcommand("uivscrolloffset", reinterpret_cast<identfun>(+[] () { { if(buildparent && buildparent->istype<Scroller>()) { Scroller *scroller = static_cast<Scroller *>(buildparent); floatret(scroller->offsety); } }; }));
         addcommand("uihscrollbar", reinterpret_cast<identfun>(+[] (uint *children) { BUILD(HorizontalScrollBar, o, o->setup(), children); }), "e", Id_Command);
         addcommand("uivscrollbar", reinterpret_cast<identfun>(+[] (uint *children) { BUILD(VerticalScrollBar, o, o->setup(), children); }), "e", Id_Command);
         addcommand("uiscrollarrow", reinterpret_cast<identfun>(+[] (float *dir, uint *children) { BUILD(ScrollArrow, o, o->setup(*dir), children); }), "fe", Id_Command);
@@ -4653,7 +4653,7 @@ namespace UI
         addcommand("uiwrapcontext", reinterpret_cast<identfun>(+[] (tagval *text, float *wrap, float *scale, uint *children) { buildtext(*text, *scale, FONTH*uicontextscale, Color(255, 255, 255), *wrap, children); }), "tffe", Id_Command);
         addcommand("uitexteditor", reinterpret_cast<identfun>(+[] (char *name, int *length, int *height, float *scale, char *initval, int *mode, uint *children) { BUILD(TextEditor, o, o->setup(name, *length, *height, (*scale <= 0 ? 1 : *scale) * uitextscale, initval, *mode <= 0 ? Editor_Forever : *mode), children); }), "siifsie", Id_Command);
         addcommand("uifont", reinterpret_cast<identfun>(+[] (char *name, uint *children) { BUILD(Font, o, o->setup(name), children); }), "se", Id_Command);
-        addcommand("uiabovehud", reinterpret_cast<identfun>(+[] () { { if(window) window->abovehud = true; }; }), "", Id_Command);;
+        addcommand("uiabovehud", reinterpret_cast<identfun>(+[] () { { if(window) window->abovehud = true; }; }));;
         addcommand("uiconsole", reinterpret_cast<identfun>(+[] (float *minw, float *minh, uint *children) { BUILD(Console, o, o->setup(*minw, *minh), children); }), "ffe", Id_Command);
         addcommand("uifield", reinterpret_cast<identfun>(+[] (ident *var, int *length, uint *onchange, float *scale, uint *children) { BUILD(Field, o, o->setup(var, *length, onchange, (*scale <= 0 ? 1 : *scale) * uitextscale), children); }), "riefe", Id_Command);
         addcommand("uikeyfield", reinterpret_cast<identfun>(+[] (ident *var, int *length, uint *onchange, float *scale, uint *children) { BUILD(KeyField, o, o->setup(var, *length, onchange, (*scale <= 0 ? 1 : *scale) * uitextscale), children); }), "riefe", Id_Command);
@@ -4667,7 +4667,7 @@ namespace UI
         addcommand("uislotview", reinterpret_cast<identfun>(+[] (int *index, float *minw, float *minh, uint *children) { BUILD(SlotViewer, o, o->setup(*index, *minw, *minh), children); }), "iffe", Id_Command);
         addcommand("uivslotview", reinterpret_cast<identfun>(+[] (int *index, float *minw, float *minh, uint *children) { BUILD(VSlotViewer, o, o->setup(*index, *minw, *minh), children); }), "iffe", Id_Command);
 
-        addcommand("uicontextscale", reinterpret_cast<identfun>(uicontextscalecmd), "", Id_Command);
+        addcommand("uicontextscale", reinterpret_cast<identfun>(uicontextscalecmd));
         addcommand("newui", reinterpret_cast<identfun>(newui), "ssss", Id_Command);
         addcommand("uiallowinput", reinterpret_cast<identfun>(uiallowinput), "b", Id_Command);
         addcommand("uieschide", reinterpret_cast<identfun>(uieschide), "b", Id_Command);

--- a/src/engine/interface/ui.cpp
+++ b/src/engine/interface/ui.cpp
@@ -4100,7 +4100,7 @@ namespace UI
             Preview::setup(minw_, minh_);
             SETSTR(name, name_);
 
-            anim = Anim_All;
+            anim = EntAnim::All;
             if(animspec[0])
             {
                 if(isdigit(animspec[0]))
@@ -4108,11 +4108,11 @@ namespace UI
                     anim = parseint(animspec);
                     if(anim >= 0)
                     {
-                        anim %= Anim_Index;
+                        anim %= EntAnim::Index;
                     }
                     else
                     {
-                        anim = Anim_All;
+                        anim = EntAnim::All;
                     }
                 }
                 else
@@ -4124,7 +4124,7 @@ namespace UI
                     }
                 }
             }
-            anim |= Anim_Loop;
+            anim |= EntAnim::Loop;
         }
 
         static const char *typestr()

--- a/src/engine/model/skelmodel.cpp
+++ b/src/engine/model/skelmodel.cpp
@@ -692,9 +692,9 @@ void skelmodel::skeleton::interpbones(const AnimState *as, float pitch, const ve
             {
                 continue;
             }
-            if(as->cur.anim & Anim_NoPitch || (as->interp < 1 && as->prev.anim & Anim_NoPitch))
+            if(as->cur.anim & EntAnim::NoPitch || (as->interp < 1 && as->prev.anim & EntAnim::NoPitch))
             {
-                angle *= (as->cur.anim & Anim_NoPitch ? 0 : as->interp) + (as->interp < 1 && as->prev.anim & Anim_NoPitch ? 0 : 1 - as->interp);
+                angle *= (as->cur.anim & EntAnim::NoPitch ? 0 : as->interp) + (as->interp < 1 && as->prev.anim & EntAnim::NoPitch ? 0 : 1 - as->interp);
             }
             sc.bdata[b.interpindex].mulorient(quat(axis, angle*RAD), b.base);
         }
@@ -1121,7 +1121,7 @@ void skelmodel::skelmeshgroup::render(const AnimState *as, float pitch, const ve
 
     if(!skel->numframes)
     {
-        if(!(as->cur.anim & Anim_NoRender))
+        if(!(as->cur.anim & EntAnim::NoRender))
         {
             if(!vbocache->vbuf)
             {
@@ -1139,7 +1139,7 @@ void skelmodel::skelmeshgroup::render(const AnimState *as, float pitch, const ve
     }
 
     skelcacheentry &sc = skel->checkskelcache(p, as, pitch, axis, forward, !d || !d->ragdoll || d->ragdoll->skel != skel->ragdoll || d->ragdoll->millis == lastmillis ? nullptr : d->ragdoll);
-    if(!(as->cur.anim & Anim_NoRender))
+    if(!(as->cur.anim & EntAnim::NoRender))
     {
         int owner = &sc-&skel->skelcache[0];
         vbocacheentry &vc = skel->usegpuskel ? *vbocache : checkvbocache(sc, owner);
@@ -1187,7 +1187,7 @@ void skelmodel::skelmeshgroup::render(const AnimState *as, float pitch, const ve
 
     skel->calctags(p, &sc);
 
-    if(as->cur.anim & Anim_Ragdoll && skel->ragdoll && !d->ragdoll)
+    if(as->cur.anim & EntAnim::Ragdoll && skel->ragdoll && !d->ragdoll)
     {
         d->ragdoll = new ragdolldata(skel->ragdoll, p->model->scale);
         skel->initragdoll(*d->ragdoll, sc, p);

--- a/src/engine/model/skelmodel.h
+++ b/src/engine/model/skelmodel.h
@@ -501,7 +501,7 @@ struct skelmodel : animmodel
         {
             T *vverts = 0;
             bindpos(ebuf, vc.vbuf, &vverts->pos, vertsize);
-            if(as->cur.anim & Anim_NoSkin)
+            if(as->cur.anim & EntAnim::NoSkin)
             {
                 if(enabletangents)
                 {

--- a/src/engine/model/vertmodel.cpp
+++ b/src/engine/model/vertmodel.cpp
@@ -392,7 +392,7 @@ void vertmodel::vertmeshgroup::preload(part *p)
 
 void vertmodel::vertmeshgroup::render(const AnimState *as, float pitch, const vec &axis, const vec &forward, dynent *d, part *p)
 {
-    if(as->cur.anim & Anim_NoRender)
+    if(as->cur.anim & EntAnim::NoRender)
     {
         for(int i = 0; i < p->links.length(); i++)
         {

--- a/src/engine/model/vertmodel.h
+++ b/src/engine/model/vertmodel.h
@@ -201,7 +201,7 @@ struct vertmodel : animmodel
         {
             T *vverts = 0;
             bindpos(ebuf, vc.vbuf, &vverts->pos, vertsize);
-            if(as->cur.anim & Anim_NoSkin)
+            if(as->cur.anim & EntAnim::NoSkin)
             {
                 if(enabletangents)
                 {

--- a/src/engine/render/octarender.cpp
+++ b/src/engine/render/octarender.cpp
@@ -2506,5 +2506,5 @@ void cubeworld::allchanged(bool load)
 
 void initoctarendercmds()
 {
-    addcommand("recalc", reinterpret_cast<identfun>(+[](){rootworld.allchanged(true);}), "", Id_Command);
+    addcommand("recalc", reinterpret_cast<identfun>(+[](){rootworld.allchanged(true);}));
 }

--- a/src/engine/render/rendergl.cpp
+++ b/src/engine/render/rendergl.cpp
@@ -1950,8 +1950,8 @@ void cleanupgl()
 void initrenderglcmds()
 {
     addcommand("glext", reinterpret_cast<identfun>(glext), "s", Id_Command);
-    addcommand("getcamyaw", reinterpret_cast<identfun>(+[](){floatret(camera1->yaw);}), "", Id_Command);
-    addcommand("getcampitch", reinterpret_cast<identfun>(+[](){floatret(camera1->pitch);}), "", Id_Command);
-    addcommand("getcamroll", reinterpret_cast<identfun>(+[](){floatret(camera1->roll);}), "", Id_Command);
-    addcommand("getcampos", reinterpret_cast<identfun>(+[](){DEF_FORMAT_STRING(pos, "%s %s %s", floatstr(camera1->o.x), floatstr(camera1->o.y), floatstr(camera1->o.z)); result(pos);}), "", Id_Command);
+    addcommand("getcamyaw", reinterpret_cast<identfun>(+[](){floatret(camera1->yaw);}));
+    addcommand("getcampitch", reinterpret_cast<identfun>(+[](){floatret(camera1->pitch);}));
+    addcommand("getcamroll", reinterpret_cast<identfun>(+[](){floatret(camera1->roll);}));
+    addcommand("getcampos", reinterpret_cast<identfun>(+[](){DEF_FORMAT_STRING(pos, "%s %s %s", floatstr(camera1->o.x), floatstr(camera1->o.y), floatstr(camera1->o.z)); result(pos);}));
 }

--- a/src/engine/render/renderlights.cpp
+++ b/src/engine/render/renderlights.cpp
@@ -4199,5 +4199,5 @@ void cleanuplights()
 
 void initrenderlightscmds() 
 {
-    addcommand("usepacknorm", reinterpret_cast<identfun>(+[](){intret(usepacknorm() ? 1 : 0);}), "", Id_Command);
+    addcommand("usepacknorm", reinterpret_cast<identfun>(+[](){intret(usepacknorm() ? 1 : 0);}));
 }

--- a/src/engine/render/rendermodel.cpp
+++ b/src/engine/render/rendermodel.cpp
@@ -713,13 +713,13 @@ static void renderbatchedmodel(model *m, const batchedmodel &b)
     int anim = b.anim;
     if(shadowmapping > ShadowMap_Reflect)
     {
-        anim |= Anim_NoSkin;
+        anim |= EntAnim::NoSkin;
     }
     else
     {
         if(b.flags&Model_FullBright)
         {
-            anim |= Anim_FullBright;
+            anim |= EntAnim::FullBright;
         }
     }
 
@@ -1229,7 +1229,7 @@ void rendermodel(const char *mdl, int anim, const vec &o, float yaw, float pitch
     {
         if(d->ragdoll)
         {
-            if(anim & Anim_Ragdoll && d->ragdoll->millis >= basetime)
+            if(anim & EntAnim::Ragdoll && d->ragdoll->millis >= basetime)
             {
                 radius = std::max(radius, d->ragdoll->radius);
                 center = d->ragdoll->center;
@@ -1241,7 +1241,7 @@ void rendermodel(const char *mdl, int anim, const vec &o, float yaw, float pitch
                 d->ragdoll = nullptr;
             }
         }
-        if(anim & Anim_Ragdoll)
+        if(anim & EntAnim::Ragdoll)
         {
             flags &= ~(Model_CullVFC | Model_CullOccluded | Model_CullQuery);
         }
@@ -1262,7 +1262,7 @@ hasboundbox:
 
     if(flags&Model_NoRender)
     {
-        anim |= Anim_NoRender;
+        anim |= EntAnim::NoRender;
     }
 
     if(a)
@@ -1310,7 +1310,7 @@ hasboundbox:
         setaamask(true);
         if(flags&Model_FullBright)
         {
-            anim |= Anim_FullBright;
+            anim |= EntAnim::FullBright;
         }
         m->render(anim, basetime, basetime2, o, yaw, pitch, roll, d, a, size, color);
         m->endrender();
@@ -1360,7 +1360,7 @@ int intersectmodel(const char *mdl, int anim, const vec &pos, float yaw, float p
     {
         return -1;
     }
-    if(d && d->ragdoll && (!(anim & Anim_Ragdoll) || d->ragdoll->millis < basetime))
+    if(d && d->ragdoll && (!(anim & EntAnim::Ragdoll) || d->ragdoll->millis < basetime))
     {
         if(d->ragdoll)
         {

--- a/src/engine/render/rendermodel.cpp
+++ b/src/engine/render/rendermodel.cpp
@@ -1502,7 +1502,7 @@ void initrendermodelcmds()
     addcommand("mdlalphashadow", reinterpret_cast<identfun>(mdlalphashadow), "i", Id_Command);
     addcommand("mdlbb", reinterpret_cast<identfun>(mdlbb), "fff", Id_Command);
     addcommand("mdlextendbb", reinterpret_cast<identfun>(mdlextendbb), "fff", Id_Command);
-    addcommand("mdlname", reinterpret_cast<identfun>(mdlname), "", Id_Command);
+    addcommand("mdlname", reinterpret_cast<identfun>(mdlname));
     addcommand("rdvert", reinterpret_cast<identfun>(rdvert), "ffff", Id_Command);
     addcommand("rdeye", reinterpret_cast<identfun>(rdeye), "i", Id_Command);
     addcommand("rdtri", reinterpret_cast<identfun>(rdtri), "iii", Id_Command);
@@ -1514,7 +1514,7 @@ void initrendermodelcmds()
     addcommand("mapmodel", reinterpret_cast<identfun>(mapmodel), "s", Id_Command);
     addcommand("mapmodelname", reinterpret_cast<identfun>(mapmodelnamecmd), "ii", Id_Command);
     addcommand("mapmodelloaded", reinterpret_cast<identfun>(mapmodelloaded), "i", Id_Command);
-    addcommand("nummapmodels", reinterpret_cast<identfun>(nummapmodels), "", Id_Command);
+    addcommand("nummapmodels", reinterpret_cast<identfun>(nummapmodels));
     addcommand("clearmodel", reinterpret_cast<identfun>(clearmodel), "s", Id_Command);
     addcommand("findanims", reinterpret_cast<identfun>(findanimscmd), "s", Id_Command);
 }

--- a/src/engine/render/renderva.cpp
+++ b/src/engine/render/renderva.cpp
@@ -408,7 +408,7 @@ namespace
 
     void rendermapmodel(extentity &e)
     {
-        int anim = Anim_Mapmodel | Anim_Loop, basetime = 0;
+        int anim = Anim_Mapmodel | EntAnim::Loop, basetime = 0;
         rendermapmodel(e.attr1, anim, e.o, e.attr2, e.attr3, e.attr4, Model_CullVFC | Model_CullDist, basetime, e.attr5 > 0 ? e.attr5/100.0f : 1.0f);
     }
 

--- a/src/engine/render/renderwindow.cpp
+++ b/src/engine/render/renderwindow.cpp
@@ -743,6 +743,6 @@ void getfpscmd(int *raw)
 void initrenderwindowcmds()
 {
     addcommand("getfps", reinterpret_cast<identfun>(getfpscmd), "i", Id_Command);
-    addcommand("resetgl", reinterpret_cast<identfun>(resetgl), "", Id_Command);
+    addcommand("resetgl", reinterpret_cast<identfun>(resetgl));
     addcommand("screenres", reinterpret_cast<identfun>(screenres), "ii", Id_Command);
 }

--- a/src/engine/render/shader.cpp
+++ b/src/engine/render/shader.cpp
@@ -2202,8 +2202,8 @@ void initshadercmds()
     addcommand("isshaderdefined", reinterpret_cast<identfun>(+[](const char* name){intret(lookupshaderbyname(name) ? 1 : 0);}), "s", Id_Command);
     addcommand("setshaderparam", reinterpret_cast<identfun>(+[](char *name, float *x, float *y, float *z, float *w){addslotparam(name, *x, *y, *z, *w);}), "sfFFf", Id_Command);
     addcommand("reuseuniformparam", reinterpret_cast<identfun>(+[](char *name, float *x, float *y, float *z, float *w){addslotparam(name, *x, *y, *z, *w, SlotShaderParam::REUSE);}), "sfFFf", Id_Command);
-    addcommand("clearpostfx", reinterpret_cast<identfun>(clearpostfx), "", Id_Command);
+    addcommand("clearpostfx", reinterpret_cast<identfun>(clearpostfx));
     addcommand("addpostfx", reinterpret_cast<identfun>(addpostfxcmd), "siisffff", Id_Command);
     addcommand("setpostfx", reinterpret_cast<identfun>(setpostfx), "sffff", Id_Command);
-    addcommand("resetshaders", reinterpret_cast<identfun>(resetshaders), "", Id_Command);
+    addcommand("resetshaders", reinterpret_cast<identfun>(resetshaders));
 }

--- a/src/engine/render/texture.cpp
+++ b/src/engine/render/texture.cpp
@@ -3335,7 +3335,7 @@ void LocalShaderParam::setv(const uint *u, int n)
 }
 void inittexturecmds() {
     addcommand("texturereset", reinterpret_cast<identfun>(texturereset), "i", Id_Command);
-    addcommand("materialreset", reinterpret_cast<identfun>(materialreset), "", Id_Command);
+    addcommand("materialreset", reinterpret_cast<identfun>(materialreset));
     addcommand("decalreset", reinterpret_cast<identfun>(decalreset), "i", Id_Command);
     addcommand("compactvslots", reinterpret_cast<identfun>(+[](int *cull){multiplayerwarn();rootworld.compactvslots(*cull!=0);rootworld.allchanged();}), "i", Id_Command);
     addcommand("texture", reinterpret_cast<identfun>(texture), "ssiiif", Id_Command);

--- a/src/engine/world/entities.cpp
+++ b/src/engine/world/entities.cpp
@@ -151,8 +151,8 @@ bool animinfo::operator==(const animinfo &o) const
 {
     return frame==o.frame
         && range==o.range
-        && (anim&(Anim_SetTime | Anim_Dir)) == (o.anim & (Anim_SetTime | Anim_Dir))
-        && (anim & Anim_SetTime || basetime == o.basetime)
+        && (anim&(EntAnim::SetTime | EntAnim::Dir)) == (o.anim & (EntAnim::SetTime | EntAnim::Dir))
+        && (anim & EntAnim::SetTime || basetime == o.basetime)
         && speed == o.speed;
 }
 
@@ -160,8 +160,8 @@ bool animinfo::operator!=(const animinfo &o) const
 {
     return frame!=o.frame
         || range!=o.range
-        || (anim&(Anim_SetTime | Anim_Dir)) != (o.anim & (Anim_SetTime | Anim_Dir))
-        || (!(anim & Anim_SetTime) && basetime != o.basetime)
+        || (anim&(EntAnim::SetTime | EntAnim::Dir)) != (o.anim & (EntAnim::SetTime | EntAnim::Dir))
+        || (!(anim & EntAnim::SetTime) && basetime != o.basetime)
         || speed != o.speed;
 }
 

--- a/src/engine/world/heightmap.cpp
+++ b/src/engine/world/heightmap.cpp
@@ -533,8 +533,8 @@ namespace hmap
 
 void initheightmapcmds()
 {
-    addcommand("hmapcancel", reinterpret_cast<identfun>(hmap::cancel), "", Id_Command);
-    addcommand("hmapselect", reinterpret_cast<identfun>(hmap::hmapselect), "", Id_Command);
-    addcommand("clearhbrush", reinterpret_cast<identfun>(hmap::clearhbrush), "", Id_Command);
+    addcommand("hmapcancel", reinterpret_cast<identfun>(hmap::cancel));
+    addcommand("hmapselect", reinterpret_cast<identfun>(hmap::hmapselect));
+    addcommand("clearhbrush", reinterpret_cast<identfun>(hmap::clearhbrush));
     addcommand("hbrushvert", reinterpret_cast<identfun>(hmap::hbrushvert), "iii", Id_Command);
 }

--- a/src/engine/world/octaedit.cpp
+++ b/src/engine/world/octaedit.cpp
@@ -1814,10 +1814,10 @@ void initoctaeditcmds()
     //unary + operator converts to function pointer
     addcommand("moving",        reinterpret_cast<identfun>(+movingcmd), "b", Id_Command);
 
-    addcommand("entcancel",     reinterpret_cast<identfun>(entcancel), "", Id_Command); ///
-    addcommand("cubecancel",    reinterpret_cast<identfun>(cubecancel), "", Id_Command); ///
-    addcommand("cancelsel",     reinterpret_cast<identfun>(cancelsel), "", Id_Command); ///
-    addcommand("reorient",      reinterpret_cast<identfun>(reorient), "", Id_Command); ///
+    addcommand("entcancel",     reinterpret_cast<identfun>(entcancel)); ///
+    addcommand("cubecancel",    reinterpret_cast<identfun>(cubecancel)); ///
+    addcommand("cancelsel",     reinterpret_cast<identfun>(cancelsel)); ///
+    addcommand("reorient",      reinterpret_cast<identfun>(reorient)); ///
 
     static auto selextend = [] ()
     {
@@ -1838,7 +1838,7 @@ void initoctaeditcmds()
             }
         }
     };
-    addcommand("selextend",     reinterpret_cast<identfun>(+selextend), "", Id_Command);
+    addcommand("selextend",     reinterpret_cast<identfun>(+selextend));
 
     static auto selmoved = [] ()
     {
@@ -1876,17 +1876,17 @@ void initoctaeditcmds()
         std::swap(sel, savedsel);
     };
 
-    addcommand("selmoved",      reinterpret_cast<identfun>(+selmoved), "", Id_Command);
-    addcommand("selsave",       reinterpret_cast<identfun>(+selsave), "", Id_Command);
-    addcommand("selrestore",    reinterpret_cast<identfun>(+selrestore), "", Id_Command);
-    addcommand("selswap",       reinterpret_cast<identfun>(+selswap), "", Id_Command);
+    addcommand("selmoved",      reinterpret_cast<identfun>(+selmoved));
+    addcommand("selsave",       reinterpret_cast<identfun>(+selsave));
+    addcommand("selrestore",    reinterpret_cast<identfun>(+selrestore));
+    addcommand("selswap",       reinterpret_cast<identfun>(+selswap));
 
     static auto haveselcmd = [] ()
     {
         intret(havesel ? selchildcount : 0);
     };
 
-    addcommand("havesel",       reinterpret_cast<identfun>(+haveselcmd), "", Id_Command);
+    addcommand("havesel",       reinterpret_cast<identfun>(+haveselcmd));
 
 
     static auto selchildcountcmd = [] ()
@@ -1900,7 +1900,7 @@ void initoctaeditcmds()
             intret(selchildcount);
         }
     };
-    addcommand("selchildnum", reinterpret_cast<identfun>(+selchildcountcmd), "", Id_Command);
+    addcommand("selchildnum", reinterpret_cast<identfun>(+selchildcountcmd));
 
 
     static auto selchildmatcmd = [] (char *prefix)
@@ -1916,7 +1916,7 @@ void initoctaeditcmds()
     {
         pruneundos(0);
     };
-    addcommand("clearundos",    reinterpret_cast<identfun>(+clearundos), "", Id_Command); //run pruneundos but with a cache size of zero
+    addcommand("clearundos",    reinterpret_cast<identfun>(+clearundos)); //run pruneundos but with a cache size of zero
     
     static auto delprefab = [] (char *name)
     {
@@ -2016,7 +2016,7 @@ void initoctaeditcmds()
             if(prevstat == curstat) curstat = (val); \
             intret(curstat); \
         }; \
-        addcommand(#name, reinterpret_cast<identfun>(+name), "", Id_Command);
+        addcommand(#name, reinterpret_cast<identfun>(+name));
 
     EDITSTAT(wtr, wtris);
     EDITSTAT(vtr, (vtris*100)/std::max(wtris, 1));

--- a/src/engine/world/octaworld.cpp
+++ b/src/engine/world/octaworld.cpp
@@ -1850,5 +1850,5 @@ void invalidatemerges(cube &c)
 
 void initoctaworldcmds()
 {
-    addcommand("printcube", reinterpret_cast<identfun>(printcube), "", Id_Command);
+    addcommand("printcube", reinterpret_cast<identfun>(printcube));
 }

--- a/src/engine/world/worldio.cpp
+++ b/src/engine/world/worldio.cpp
@@ -1171,5 +1171,5 @@ bool cubeworld::load_world(const char *mname, const char *gameident, const char 
 
 void initworldiocmds()
 {
-    addcommand("mapcfgname", reinterpret_cast<identfun>(mapcfgname), "", Id_Command);
+    addcommand("mapcfgname", reinterpret_cast<identfun>(mapcfgname));
 }


### PR DESCRIPTION
The default arguments are defined by the `addcommand` function, so passing 
them again is redundant.