### PR TITLE
Use `std::array` for octree

### DIFF
--- a/src/engine/render/normal.cpp
+++ b/src/engine/render/normal.cpp
@@ -216,7 +216,7 @@ namespace //internal functionality not seen by other files
             size >>= 1;
             for(int i = 0; i < 8; ++i)
             {
-                addnormals(c.children[i], ivec(i, o, size), size);
+                addnormals((*c.children)[i], ivec(i, o, size), size);
             }
             return;
         }
@@ -396,7 +396,7 @@ void cubeworld::calcnormals(bool lerptjoints)
     }
     for(int i = 0; i < 8; ++i)
     {
-        addnormals(worldroot[i], ivec(i, ivec(0, 0, 0), mapsize()/2), mapsize()/2);
+        addnormals((*worldroot)[i], ivec(i, ivec(0, 0, 0), mapsize()/2), mapsize()/2);
     }
 }
 
@@ -436,7 +436,7 @@ int smoothangle(int id, int angle)
     return id;
 }
 
-void initnormalcmds() 
+void initnormalcmds()
 {
     addcommand("smoothangle", reinterpret_cast<identfun>(+[] (int *id, int *angle) {intret(smoothangle(*id, *angle));}), "ib", Id_Command);
 }

--- a/src/engine/render/octarender.cpp
+++ b/src/engine/render/octarender.cpp
@@ -2405,7 +2405,7 @@ void destroyva(vtxarray *va, bool reparent)
     delete va;
 }
 
-//recursively clear vertex arrays for a cube object and its children
+//recursively clear vertex arrays for an array of eight cube objects and their children
 void clearvas(std::array<cube, 8> &c)
 {
     for(int i = 0; i < 8; ++i)

--- a/src/engine/render/octarender.h
+++ b/src/engine/render/octarender.h
@@ -95,7 +95,7 @@ extern int allocva;
 extern ushort encodenormal(const vec &n);
 extern void guessnormals(const vec *pos, int numverts, vec *normals);
 extern void reduceslope(ivec &n);
-extern void clearvas(cube *c);
+extern void clearvas(std::array<cube, 8> &c);
 extern void destroyva(vtxarray *va, bool reparent = true);
 extern void updatevabb(vtxarray *va, bool force = false);
 extern void updatevabbs(bool force = false);

--- a/src/engine/render/rendergl.cpp
+++ b/src/engine/render/rendergl.cpp
@@ -1319,14 +1319,14 @@ void bindminimap()
     glBindTexture(GL_TEXTURE_2D, minimaptex);
 }
 
-void clipminimap(ivec &bbmin, ivec &bbmax, const cube *c, const ivec &co = ivec(0, 0, 0), int size = rootworld.mapsize()>>1)
+void clipminimap(ivec &bbmin, ivec &bbmax, const std::array<cube, 8> &c, const ivec &co = ivec(0, 0, 0), int size = rootworld.mapsize()>>1)
 {
     for(int i = 0; i < 8; ++i)
     {
         ivec o(i, co, size);
         if(c[i].children)
         {
-            clipminimap(bbmin, bbmax, c[i].children, o, size>>1);
+            clipminimap(bbmin, bbmax, *(c[i].children), o, size>>1);
         }
         else if(!(c[i].issolid()) && (c[i].material&MatFlag_Clip)!=Mat_Clip)
         {
@@ -1390,7 +1390,7 @@ void drawminimap(int yaw, int pitch, vec loc, const cubeworld& world, int scalef
     {
         ivec clipmin(rootworld.mapsize(), rootworld.mapsize(), rootworld.mapsize()),
              clipmax(0, 0, 0);
-        clipminimap(clipmin, clipmax, world.worldroot);
+        clipminimap(clipmin, clipmax, *world.worldroot);
         for(int k = 0; k < 2; ++k)
         {
             bbmin[k] = std::max(bbmin[k], clipmin[k]);

--- a/src/engine/render/renderva.cpp
+++ b/src/engine/render/renderva.cpp
@@ -323,7 +323,7 @@ namespace
             br.x <= va.bbmax.x && br.y <= va.bbmax.y && br.z <= va.bbmax.z;
     }
 
-    bool bboccluded(const ivec &bo, const ivec &br, cube *c, const ivec &o, int size)
+    bool bboccluded(const ivec &bo, const ivec &br, const std::array<cube, 8> &c, const ivec &o, int size)
     {
         LOOP_OCTA_BOX(o, size, bo, br)
         {
@@ -336,7 +336,7 @@ namespace
                     continue;
                 }
             }
-            if(c[i].children && bboccluded(bo, br, c[i].children, co, size>>1))
+            if(c[i].children && bboccluded(bo, br, *(c[i].children), co, size>>1))
             {
                 continue;
             }
@@ -2309,9 +2309,9 @@ bool cubeworld::bboccluded(const ivec &bo, const ivec &br) const
     int scale = worldscale-1;
     if(diff&(1<<scale))
     {
-        return ::bboccluded(bo, br, worldroot, ivec(0, 0, 0), 1<<scale);
+        return ::bboccluded(bo, br, *worldroot, ivec(0, 0, 0), 1<<scale);
     }
-    const cube *c = &worldroot[OCTA_STEP(bo.x, bo.y, bo.z, scale)];
+    const cube *c = &(*worldroot)[OCTA_STEP(bo.x, bo.y, bo.z, scale)];
     if(c->ext && c->ext->va)
     {
         vtxarray *va = c->ext->va;
@@ -2323,7 +2323,7 @@ bool cubeworld::bboccluded(const ivec &bo, const ivec &br) const
     scale--;
     while(c->children && !(diff&(1<<scale)))
     {
-        c = &c->children[OCTA_STEP(bo.x, bo.y, bo.z, scale)];
+        c = &(*c->children)[OCTA_STEP(bo.x, bo.y, bo.z, scale)];
         if(c->ext && c->ext->va)
         {
             vtxarray *va = c->ext->va;
@@ -2336,7 +2336,7 @@ bool cubeworld::bboccluded(const ivec &bo, const ivec &br) const
     }
     if(c->children)
     {
-        return ::bboccluded(bo, br, c->children, ivec(bo).mask(~((2<<scale)-1)), 1<<scale);
+        return ::bboccluded(bo, br, *(c->children), ivec(bo).mask(~((2<<scale)-1)), 1<<scale);
     }
     return false;
 }
@@ -2699,7 +2699,7 @@ bool renderexplicitsky(bool outline)
 
 void cubeworld::cleanupva()
 {
-    clearvas(worldroot);
+    clearvas(*worldroot);
     occlusionengine.clearqueries();
     cleanupbb();
     cleanupgrass();

--- a/src/engine/render/stain.cpp
+++ b/src/engine/render/stain.cpp
@@ -373,7 +373,7 @@ class stainrenderer
             {
                 verts[i].lastvert = verts[i].endvert;
             }
-            gentris(world.worldroot, ivec(0, 0, 0), rootworld.mapsize()>>1);
+            gentris(*world.worldroot, ivec(0, 0, 0), rootworld.mapsize()>>1);
             for(int i = 0; i < StainBuffer_Number; ++i)
             {
                 stainbuffer &buf = verts[i];
@@ -753,7 +753,7 @@ class stainrenderer
             }
         }
 
-        void findescaped(const cube *c, const ivec &o, int size, int escaped)
+        void findescaped(const std::array<cube, 8> &c, const ivec &o, int size, int escaped)
         {
             for(int i = 0; i < 8; ++i)
             {
@@ -763,7 +763,7 @@ class stainrenderer
                     ivec co(i, o, size);
                     if(cu.children)
                     {
-                        findescaped(cu.children, co, size>>1, cu.escaped);
+                        findescaped(*cu.children, co, size>>1, cu.escaped);
                     }
                     else
                     {
@@ -783,7 +783,7 @@ class stainrenderer
             }
         }
 
-        void gentris(const cube *c, const ivec &o, int size, int escaped = 0)
+        void gentris(const std::array<cube, 8> &c, const ivec &o, int size, int escaped = 0)
         {
             int overlap = octaboxoverlap(o, size, bbmin, bbmax);
             for(int i = 0; i < 8; ++i)
@@ -805,7 +805,7 @@ class stainrenderer
                     }
                     if(cu.children)
                     {
-                        gentris(cu.children, co, size>>1, cu.escaped);
+                        gentris(*cu.children, co, size>>1, cu.escaped);
                     }
                     else
                     {
@@ -837,7 +837,7 @@ class stainrenderer
                     ivec co(i, o, size);
                     if(cu.children)
                     {
-                        findescaped(cu.children, co, size>>1, cu.escaped);
+                        findescaped(*cu.children, co, size>>1, cu.escaped);
                     }
                     else
                     {

--- a/src/engine/render/texture.cpp
+++ b/src/engine/render/texture.cpp
@@ -1225,7 +1225,7 @@ void compactvslot(VSlot &vs)
     }
 }
 
-void compactvslots(cube *c, int n)
+void compactvslots(std::array<cube ,8> &c, int n)
 {
     if((compactvslotsprogress++&0xFFF)==0)
     {
@@ -1235,7 +1235,7 @@ void compactvslots(cube *c, int n)
     {
         if(c[i].children)
         {
-            compactvslots(c[i].children);
+            compactvslots(*(c[i].children));
         }
         else
         {
@@ -1298,7 +1298,7 @@ int cubeworld::compactvslots(bool cull)
             }
         }
     }
-    ::compactvslots(worldroot);
+    ::compactvslots(*worldroot);
     int total = compactedvslots;
     compacteditvslots();
     for(uint i = 0; i < vslots.size(); i++)
@@ -1349,7 +1349,7 @@ int cubeworld::compactvslots(bool cull)
                 vs.index = compactedvslots++;
             }
         }
-        ::compactvslots(worldroot);
+        ::compactvslots(*worldroot);
         total = compactedvslots;
         compacteditvslots();
     }
@@ -1869,14 +1869,14 @@ VSlot *editvslot(const VSlot &src, const VSlot &delta)
     return clonevslot(src, delta);
 }
 
-static void fixinsidefaces(cube *c, const ivec &o, int size, int tex)
+static void fixinsidefaces(std::array<cube, 8> &c, const ivec &o, int size, int tex)
 {
     for(int i = 0; i < 8; ++i)
     {
         ivec co(i, o, size);
         if(c[i].children)
         {
-            fixinsidefaces(c[i].children, co, size>>1, tex);
+            fixinsidefaces(*(c[i].children), co, size>>1, tex);
         }
         else
         {

--- a/src/engine/render/texture.cpp
+++ b/src/engine/render/texture.cpp
@@ -1225,13 +1225,14 @@ void compactvslot(VSlot &vs)
     }
 }
 
-void compactvslots(std::array<cube ,8> &c, int n)
+//n will be capped at 8
+void compactvslots(std::array<cube, 8> &c, int n)
 {
     if((compactvslotsprogress++&0xFFF)==0)
     {
         renderprogress(std::min(static_cast<float>(compactvslotsprogress)/allocnodes, 1.0f), markingvslots ? "marking slots..." : "compacting slots...");
     }
-    for(int i = 0; i < n; ++i)
+    for(int i = 0; i < std::min(n, 8); ++i)
     {
         if(c[i].children)
         {

--- a/src/engine/render/texture.h
+++ b/src/engine/render/texture.h
@@ -11,7 +11,7 @@ extern void create3dtexture(int tnum, int w, int h, int d, const void *pixels, i
 extern bool reloadtexture(const char *name);
 extern void clearslots();
 extern void compacteditvslots();
-extern void compactvslots(cube *c, int n = 8);
+extern void compactvslots(std::array<cube, 8> &c, int n = 8);
 extern void compactvslot(int &index);
 extern void compactvslot(VSlot &vs);
 extern void reloadtextures();

--- a/src/engine/world/light.cpp
+++ b/src/engine/world/light.cpp
@@ -340,7 +340,7 @@ void PackNode::reserve(ushort tx, ushort ty, ushort tw, ushort th)
     available = std::max(child1->available, child2->available);
 }
 
-static void clearsurfaces(cube *c)
+static void clearsurfaces(std::array<cube, 8> &c)
 {
     for(int i = 0; i < 8; ++i)
     {
@@ -373,7 +373,7 @@ static void clearsurfaces(cube *c)
         }
         if(c[i].children)
         {
-            clearsurfaces(c[i].children);
+            clearsurfaces(*(c[i].children));
         }
     }
 }
@@ -604,14 +604,14 @@ static void calcsurfaces(cube &c, const ivec &co, int size, int usefacemask, int
     }
 }
 
-static void calcsurfaces(cube *c, const ivec &co, int size)
+static void calcsurfaces(std::array<cube, 8> &c, const ivec &co, int size)
 {
     for(int i = 0; i < 8; ++i)
     {
         ivec o(i, co, size);
         if(c[i].children)
         {
-            calcsurfaces(c[i].children, o, size >> 1);
+            calcsurfaces(*(c[i].children), o, size >> 1);
         }
         else if(!(c[i].isempty()))
         {
@@ -641,9 +641,9 @@ static void calcsurfaces(cube *c, const ivec &co, int size)
 void cubeworld::calclight()
 {
     remip();
-    clearsurfaces(worldroot);
+    clearsurfaces(*worldroot);
     calcnormals(filltjoints > 0);
-    calcsurfaces(worldroot, ivec(0, 0, 0), rootworld.mapsize() >> 1);
+    calcsurfaces(*worldroot, ivec(0, 0, 0), rootworld.mapsize() >> 1);
     clearnormals();
     allchanged();
 }

--- a/src/engine/world/material.cpp
+++ b/src/engine/world/material.cpp
@@ -14,6 +14,7 @@
  * the material data is saved in world files along with the octree geometry (see
  * worldio.cpp)
  */
+
 #include "../libprimis-headers/cube.h"
 #include "../../shared/geomexts.h"
 #include "../../shared/glemu.h"

--- a/src/engine/world/octacube.cpp
+++ b/src/engine/world/octacube.cpp
@@ -106,8 +106,8 @@ void cube::discardchildren(bool fixtex, int depth)
         uint filled = faceempty;
         for(int i = 0; i < 8; ++i)
         {
-            children[i].discardchildren(fixtex, depth+1);
-            filled |= children[i].faces[0];
+            (*children)[i].discardchildren(fixtex, depth+1);
+            filled |= (*children)[i].faces[0];
         }
         if(fixtex)
         {
@@ -721,7 +721,7 @@ void cube::genmerges(cube * root, const ivec &o, int size)
         int vis;
         if(this[i].children)
         {
-            this[i].children->genmerges(root, co, size>>1);
+            (this[i]).children->at(0).genmerges(root, co, size>>1);
         }
         else if(!(this[i].isempty()))
         {

--- a/src/engine/world/octaedit.cpp
+++ b/src/engine/world/octaedit.cpp
@@ -335,7 +335,7 @@ int selchildcount = 0,
     selchildmat = -1;
 
 //used in iengine.h
-void countselchild(const cube *c, const ivec &cor, int size)
+void countselchild(const std::array<cube, 8> &c, const ivec &cor, int size)
 {
     ivec ss = ivec(sel.s).mul(sel.grid);
     uchar possible = octaboxoverlap(cor, size, sel.o, ivec(sel.o).add(ss));
@@ -346,7 +346,7 @@ void countselchild(const cube *c, const ivec &cor, int size)
             ivec o(i, cor, size);
             if(c[i].children)
             {
-                countselchild(c[i].children, o, size/2);
+                countselchild(*(c[i].children), o, size/2);
             }
             else
             {
@@ -415,7 +415,7 @@ bool editmoveplane(const vec &o, const vec &ray, int d, float off, vec &handle, 
 
 //////////// ready changes to vertex arrays ////////////
 
-static void readychanges(const ivec &bbmin, const ivec &bbmax, cube *c, const ivec &cor, int size)
+static void readychanges(const ivec &bbmin, const ivec &bbmax, std::array<cube, 8> &c, const ivec &cor, int size)
 {
     LOOP_OCTA_BOX(cor, size, bbmin, bbmax)
     {
@@ -445,7 +445,7 @@ static void readychanges(const ivec &bbmin, const ivec &bbmax, cube *c, const iv
             }
             else
             {
-                readychanges(bbmin, bbmax, c[i].children, o, size/2);
+                readychanges(bbmin, bbmax, *(c[i].children), o, size/2);
             }
         }
         else
@@ -475,7 +475,7 @@ void cubeworld::commitchanges(bool force)
 
 void cubeworld::changed(const ivec &bbmin, const ivec &bbmax, bool commit)
 {
-    readychanges(bbmin, bbmax, worldroot, ivec(0, 0, 0), mapsize()/2);
+    readychanges(bbmin, bbmax, *worldroot, ivec(0, 0, 0), mapsize()/2);
     haschanged = true;
 
     if(commit)
@@ -490,7 +490,7 @@ void cubeworld::changed(const block3 &sel, bool commit)
     {
         return;
     }
-    readychanges(ivec(sel.o).sub(1), ivec(sel.s).mul(sel.grid).add(sel.o).add(1), worldroot, ivec(0, 0, 0), mapsize()/2);
+    readychanges(ivec(sel.o).sub(1), ivec(sel.s).mul(sel.grid).add(sel.o).add(1), *worldroot, ivec(0, 0, 0), mapsize()/2);
     haschanged = true;
     if(commit)
     {
@@ -511,7 +511,7 @@ static void copycube(const cube &src, cube &dst)
         dst.children = newcubes(faceempty);
         for(int i = 0; i < 8; ++i)
         {
-            copycube(src.children[i], dst.children[i]);
+            copycube((*src.children)[i], (*dst.children)[i]);
         }
     }
 }
@@ -526,8 +526,9 @@ void pastecube(const cube &src, cube &dst)
 void blockcopy(const block3 &s, int rgrid, block3 *b)
 {
     *b = s;
-    cube *q = b->c();
-    LOOP_XYZ(s, rgrid, copycube(c, *q++));
+    std::array<cube, 8> *q = b->c();
+    uint i = 0;
+    LOOP_XYZ(s, rgrid, copycube(c, (*q)[i]); i++);
 }
 
 block3 *blockcopy(const block3 &s, int rgrid)
@@ -547,10 +548,12 @@ block3 *blockcopy(const block3 &s, int rgrid)
 
 void freeblock(block3 *b, bool alloced = true)
 {
-    cube *q = b->c();
+    std::array<cube, 8> *q = b->c();
+    uint j = 0;
     for(int i = 0; i < b->size(); ++i)
     {
-        (*q++).discardchildren(); //note: incrementing pointer
+        ((*q)[j]).discardchildren();
+        j++;
     }
     if(alloced)
     {
@@ -581,12 +584,14 @@ static int undosize(undoblock *u)
     else
     {
         block3 *b = u->block();
-        cube *q = b->c();
+        std::array<cube, 8> *q = b->c();
         int size = b->size(),
             total = size;
+        uint i = 0;
         for(int j = 0; j < size; ++j)
         {
-            total += familysize(*q++)*sizeof(cube);
+            total += familysize((*q)[i])*sizeof(cube);
+            i++;
         }
         return total;
     }
@@ -648,14 +653,14 @@ void addundo(undoblock *u)
 
 VARP(nompedit, 0, 1, 1);
 
-static int countblock(const cube *c, int n = 8)
+static int countblock(const std::array<cube, 8> &c, int n = 8)
 {
     int r = 0;
     for(int i = 0; i < n; ++i)
     {
         if(c[i].children)
         {
-            r += countblock(c[i].children);
+            r += countblock(*(c[i].children));
         }
         else
         {
@@ -667,7 +672,7 @@ static int countblock(const cube *c, int n = 8)
 
 int countblock(block3 *b)
 {
-    return countblock(b->c(), b->size());
+    return countblock(*b->getcube(), b->size());
 }
 
 std::vector<editinfo *> editinfos;
@@ -681,7 +686,7 @@ static void packcube(const cube &c, B &buf)
         buf.push_back(0xFF);
         for(int i = 0; i < 8; ++i)
         {
-            packcube(c.children[i], buf);
+            packcube((*c.children)[i], buf);
         }
     }
     else
@@ -712,10 +717,10 @@ static bool packblock(const block3 &b, B &buf)
     {
         buf.push_back(reinterpret_cast<const uchar *>(&hdr)[i]);
     }
-    const cube *c = b.getcube();
+    const std::array<cube, 8> *c = b.getcube();
     for(uint i = 0; i < static_cast<uint>(b.size()); ++i)
     {
-        packcube(c[i], buf);
+        packcube((*c)[i], buf);
     }
     return true;
 }
@@ -733,7 +738,7 @@ static void packvslots(const cube &c, std::vector<uchar> &buf, std::vector<ushor
     {
         for(int i = 0; i < 8; ++i)
         {
-            packvslots(c.children[i], buf, used);
+            packvslots((*c.children)[i], buf, used);
         }
     }
     else
@@ -761,10 +766,10 @@ static void packvslots(const cube &c, std::vector<uchar> &buf, std::vector<ushor
 static void packvslots(const block3 &b, std::vector<uchar> &buf)
 {
     std::vector<ushort> used;
-    const cube *c = b.getcube();
+    const std::array<cube, 8> *c = b.getcube();
     for(int i = 0; i < b.size(); ++i)
     {
-        packvslots(c[i], buf, used);
+        packvslots((*c)[i], buf, used);
     }
     for(uint i = 0; i < sizeof(vslothdr); ++i)
     {
@@ -782,7 +787,7 @@ static void unpackcube(cube &c, B &buf)
         //recursively apply to children
         for(int i = 0; i < 8; ++i)
         {
-            unpackcube(c.children[i], buf);
+            unpackcube((*c.children)[i], buf);
         }
     }
     else
@@ -816,11 +821,11 @@ static bool unpackblock(block3 *&b, B &buf)
         return false;
     }
     *b = hdr;
-    cube *c = b->c();
+    std::array<cube, 8> *c = b->c();
     std::memset(c, 0, b->size()*sizeof(cube));
     for(int i = 0; i < b->size(); ++i)
     {
-        unpackcube(c[i], buf);
+        unpackcube((*c)[i], buf);
     }
     return true;
 }
@@ -850,7 +855,7 @@ static void unpackvslots(cube &c, ucharbuf &buf)
     {
         for(int i = 0; i < 8; ++i)
         {
-            unpackvslots(c.children[i], buf);
+            unpackvslots((*c.children)[i], buf);
         }
     }
     else
@@ -893,10 +898,10 @@ static void unpackvslots(block3 &b, ucharbuf &buf)
         unpackingvslots.emplace_back(vslotmap(hdr.index, edit ? edit : &vs));
     }
 
-    cube *c = b.c();
+    std::array<cube, 8> *c = b.c();
     for(int i = 0; i < b.size(); ++i)
     {
-        unpackvslots(c[i], buf);
+        unpackvslots((*c)[i], buf);
     }
 
     unpackingvslots.clear();
@@ -1096,8 +1101,9 @@ void cleanupprefabs()
 
 void pasteundoblock(block3 *b, const uchar *g)
 {
-    cube *s = b->c();
-    LOOP_XYZ(*b, 1<<std::min(static_cast<int>(*g++), rootworld.mapscale()-1), pastecube(*s++, c));
+    std::array<cube, 8> *s = b->c();
+    uint i = 0;
+    LOOP_XYZ(*b, 1<<std::min(static_cast<int>(*g++), rootworld.mapscale()-1), pastecube((*s)[i], c); i++);
 }
 
 //used in client prefab unpacking, handles the octree unpacking (not the entities,
@@ -1142,8 +1148,9 @@ void pasteblock(const block3 &b, selinfo &sel, bool local)
     sel.s = b.s;
     int o = sel.orient;
     sel.orient = b.orient;
-    const cube *s = b.getcube();
-    LOOP_SEL_XYZ(if(!(s->isempty()) || s->children || s->material != Mat_Air) pastecube(*s, c); s++); // 'transparent'. old opaque by 'delcube; paste'
+    const std::array<cube, 8> *s = b.getcube();
+    uint i = 0;
+    LOOP_SEL_XYZ(if(!((*s)[i].isempty()) || (*s)[i].children || (*s)[i].material != Mat_Air) pastecube((*s)[i], c); i++); // 'transparent'. old opaque by 'delcube; paste'
     sel.orient = o;
 }
 
@@ -1290,11 +1297,11 @@ static void genprefabmesh(prefabmesh &r, const cube &c, const ivec &co, int size
     //recursively apply to children
     if(c.children)
     {
-        neighborstack[++neighbordepth] = c.children;
+        neighborstack[++neighbordepth] = &(*c.children)[0];
         for(int i = 0; i < 8; ++i)
         {
             ivec o(i, co, size/2);
-            genprefabmesh(r, c.children[i], o, size/2);
+            genprefabmesh(r, (*c.children)[i], o, size/2);
         }
         --neighbordepth;
     }
@@ -1349,7 +1356,7 @@ void cubeworld::genprefabmesh(prefab &p)
     block3 b = *p.copy;
     b.o = ivec(0, 0, 0);
 
-    cube *oldworldroot = worldroot;
+    std::array<cube, 8> *oldworldroot = worldroot;
     int oldworldscale = worldscale;
 
     worldroot = newcubes();
@@ -1359,15 +1366,16 @@ void cubeworld::genprefabmesh(prefab &p)
         worldscale++;
     }
 
-    cube *s = p.copy->c();
-    LOOP_XYZ(b, b.grid, if(!(s->isempty()) || s->children) pastecube(*s, c); s++);
+    std::array<cube, 8> *s = p.copy->c();
+    uint i = 0;
+    LOOP_XYZ(b, b.grid, if(!((*s)[i].isempty()) || (*s)[i].children) pastecube((*s)[i], c); i++);
 
     prefabmesh r;
-    neighborstack[++neighbordepth] = worldroot;
+    neighborstack[++neighbordepth] = &(*worldroot)[0];
     //recursively apply to children
     for(int i = 0; i < 8; ++i)
     {
-        ::genprefabmesh(r, worldroot[i], ivec(i, ivec(0, 0, 0), mapsize()/2), mapsize()/2);
+        ::genprefabmesh(r, (*worldroot)[i], ivec(i, ivec(0, 0, 0), mapsize()/2), mapsize()/2);
     }
     --neighbordepth;
     r.setup(p);
@@ -1488,20 +1496,20 @@ void compacteditvslots()
     for(uint i = 0; i < editinfos.size(); i++)
     {
         editinfo *e = editinfos[i];
-        compactvslots(e->copy->c(), e->copy->size());
+        compactvslots(*e->copy->c(), e->copy->size());
     }
     for(undoblock *u : undos)
     {
         if(!u->numents)
         {
-            compactvslots(u->block()->c(), u->block()->size());
+            compactvslots(*u->block()->c(), u->block()->size());
         }
     }
     for(undoblock *u : redos)
     {
         if(!u->numents)
         {
-            compactvslots(u->block()->c(), u->block()->size());
+            compactvslots(*u->block()->c(), u->block()->size());
         }
     }
 }
@@ -1512,10 +1520,10 @@ ushort getmaterial(cube &c)
 {
     if(c.children)
     {
-        ushort mat = getmaterial(c.children[7]);
+        ushort mat = getmaterial((*c.children)[7]);
         for(int i = 0; i < 7; ++i)
         {
-            if(mat != getmaterial(c.children[i]))
+            if(mat != getmaterial((*c.children)[i]))
             {
                 return Mat_Air;
             }
@@ -1572,7 +1580,7 @@ void remapvslots(cube &c, bool delta, const VSlot &ds, int orient, bool &findrep
     {
         for(int i = 0; i < 8; ++i)
         {
-            remapvslots(c.children[i], delta, ds, orient, findrep, findedit);
+            remapvslots((*c.children)[i], delta, ds, orient, findrep, findedit);
         }
         return;
     }
@@ -1685,7 +1693,7 @@ void edittexcube(cube &c, int tex, int orient, bool &findrep)
     {
         for(int i = 0; i < 8; ++i)
         {
-            edittexcube(c.children[i], tex, orient, findrep);
+            edittexcube((*c.children)[i], tex, orient, findrep);
         }
     }
 }
@@ -1706,7 +1714,7 @@ void cube::setmat(ushort mat, ushort matmask, ushort filtermat, ushort filtermas
     {
         for(int i = 0; i < 8; ++i)
         {
-            children[i].setmat( mat, matmask, filtermat, filtermask, filtergeom);
+            (*children)[i].setmat( mat, matmask, filtermat, filtermask, filtergeom);
         }
     }
     else if((material&filtermask) == filtermat)

--- a/src/engine/world/octaworld.cpp
+++ b/src/engine/world/octaworld.cpp
@@ -96,9 +96,19 @@ cubeext *newcubeext(cube &c, int maxverts, bool init)
     return ext;
 }
 
-//allocates on the heap 8 new cubes, contiguously, which are returned
-//by a std::array that contains the allocated values' pointers
-std::array<cube , 8> *newcubes(uint face, int mat)
+/**
+ * @brief Returns an octet of cubes allocated on the heap.
+ *
+ * These cubes should be freed with freeocta() to prevent a leak.
+ *
+ * `allocnodes` is incremented by one for each call of this function.
+ *
+ * @param face The face values to set the eight cubes
+ * @param mat The material mask to assign to the cubes
+ *
+ * @return a std::array<cube, 8> pointer pointing to an array containing the created cubes
+ */
+std::array<cube, 8> *newcubes(uint face, int mat)
 {
     std::array<cube, 8> *c = new std::array<cube, 8> ;
     for(int i = 0; i < 8; ++i)

--- a/src/engine/world/octaworld.cpp
+++ b/src/engine/world/octaworld.cpp
@@ -40,8 +40,6 @@ const uchar faceedgesidx[6][4] = // ordered edges surrounding each orient
 
 cubeworld rootworld;
 
-void calcmerges();
-
 cubeext *growcubeext(cubeext *old, int maxverts)
 {
     cubeext *ext = reinterpret_cast<cubeext *>(new uchar[sizeof(cubeext) + maxverts*sizeof(vertinfo)]);
@@ -98,27 +96,30 @@ cubeext *newcubeext(cube &c, int maxverts, bool init)
     return ext;
 }
 
-cube *newcubes(uint face, int mat)
+//allocates on the heap 8 new cubes, contiguously, which are returned
+//by a std::array that contains the allocated values' pointers
+std::array<cube , 8> *newcubes(uint face, int mat)
 {
-    cube *c = new cube[8];
+    std::array<cube, 8> *c = new std::array<cube, 8> ;
     for(int i = 0; i < 8; ++i)
     {
-        c->children = nullptr;
-        c->ext = nullptr;
-        c->visible = 0;
-        c->merged = 0;
-        setcubefaces(*c, face);
+        (*c)[i].children = nullptr;
+        (*c)[i].ext = nullptr;
+        (*c)[i].visible = 0;
+        (*c)[i].merged = 0;
+        setcubefaces((*c)[i], face);
         for(int l = 0; l < 6; ++l) //note this is a loop l (level 4)
         {
-            c->texture[l] = Default_Geom;
+            (*c)[i].texture[l] = Default_Geom;
         }
-        c->material = mat;
-        c++;
+        (*c)[i].material = mat;
     }
     allocnodes++;
-    return c-8;
+    return c;
 }
 
+//returns the size of the tree starting from the specified cube going down
+//the cube in question is counted as part of the family
 int familysize(const cube &c)
 {
     int size = 1;
@@ -126,13 +127,13 @@ int familysize(const cube &c)
     {
         for(int i = 0; i < 8; ++i)
         {
-            size += familysize(c.children[i]);
+            size += familysize((*c.children)[i]);
         }
     }
     return size;
 }
 
-void freeocta(cube *c)
+void freeocta(std::array<cube, 8> *&c)
 {
     if(!c)
     {
@@ -140,9 +141,10 @@ void freeocta(cube *c)
     }
     for(int i = 0; i < 8; ++i)
     {
-        c[i].discardchildren();
+        (*c)[i].discardchildren();
     }
-    delete[] c;
+    delete c;
+    c = nullptr;
     allocnodes--;
 }
 
@@ -196,37 +198,37 @@ void printcube()
     conoutf(Console_Debug, " z  %.8x", c.faces[2]);
 }
 
-void validatec(cube *c, int size)
+void validatec(std::array<cube, 8> *&c, int size)
 {
     for(int i = 0; i < 8; ++i)
     {
-        if(c[i].children)
+        if((*c)[i].children)
         {
             if(size<=1)
             {
-                setcubefaces(c[i], facesolid);
-                c[i].discardchildren(true);
+                setcubefaces((*c)[i], facesolid);
+                (*c)[i].discardchildren(true);
             }
             else
             {
-                validatec(c[i].children, size>>1);
+                validatec((*c)[i].children, size>>1);
             }
         }
         else if(size > 0x1000)
         {
-            subdividecube(c[i], true, false);
-            validatec(c[i].children, size>>1);
+            subdividecube((*c)[i], true, false);
+            validatec((*c)[i].children, size>>1);
         }
         else
         {
             for(int j = 0; j < 3; ++j)
             {
-                uint f  = c[i].faces[j],
+                uint f  = (*c)[i].faces[j],
                      e0 = f&0x0F0F0F0FU,
                      e1 = (f>>4)&0x0F0F0F0FU;
                 if(e0 == e1 || ((e1+0x07070707U)|(e1-e0))&0xF0F0F0F0U)
                 {
-                    setcubefaces(c[i], faceempty);
+                    setcubefaces((*c)[i], faceempty);
                     break;
                 }
             }
@@ -244,7 +246,7 @@ cube &cubeworld::lookupcube(const ivec &to, int tsize, ivec &ro, int &rsize)
         tz = std::clamp(to.z, 0, mapsize()-1);
     int scale = worldscale-1,
         csize = std::abs(tsize);
-    cube *c = &worldroot[OCTA_STEP(tx, ty, tz, scale)];
+    cube *c = &(*worldroot)[OCTA_STEP(tx, ty, tz, scale)];
     if(!c)
     {
         return emptycube;
@@ -261,13 +263,13 @@ cube &cubeworld::lookupcube(const ivec &to, int tsize, ivec &ro, int &rsize)
                     {
                         subdividecube(*c);
                         scale--;
-                        c = &c->children[OCTA_STEP(tx, ty, tz, scale)];
+                        c = &(*c->children)[OCTA_STEP(tx, ty, tz, scale)];
                     } while(!(csize>>scale));
                 }
                 break;
             }
             scale--;
-            c = &c->children[OCTA_STEP(tx, ty, tz, scale)];
+            c = &(*c->children)[OCTA_STEP(tx, ty, tz, scale)];
         } while(!(csize>>scale));
     }
     ro = ivec(tx, ty, tz).mask(~0U<<scale);
@@ -283,11 +285,11 @@ int cubeworld::lookupmaterial(const vec &v)
         return Mat_Air;
     }
     int scale = worldscale-1;
-    cube *c = &worldroot[OCTA_STEP(o.x, o.y, o.z, scale)];
+    cube *c = &(*worldroot)[OCTA_STEP(o.x, o.y, o.z, scale)];
     while(c->children)
     {
         scale--;
-        c = &c->children[OCTA_STEP(o.x, o.y, o.z, scale)];
+        c = &(*c->children)[OCTA_STEP(o.x, o.y, o.z, scale)];
     }
     return c->material;
 }
@@ -316,7 +318,7 @@ const cube &cubeworld::neighborcube(int orient, const ivec &co, int size, ivec &
         return emptycube;
     }
     int scale = worldscale;
-    const cube *nc = worldroot;
+    const cube *nc = &(*worldroot)[0];
     if(neighbordepth >= 0)
     {
         scale -= neighbordepth + 1;
@@ -335,7 +337,7 @@ const cube &cubeworld::neighborcube(int orient, const ivec &co, int size, ivec &
         do
         {
             scale--;
-            nc = &nc->children[OCTA_STEP(n.x, n.y, n.z, scale)];
+            nc = &(*nc->children)[OCTA_STEP(n.x, n.y, n.z, scale)];
         } while(!(size>>scale) && nc->children);
     }
     ro = n.mask(~0U<<scale);
@@ -366,7 +368,7 @@ static int octacubeindex(int d, int x, int y, int z)
 
 int getmippedtexture(const cube &p, int orient)
 {
-    cube *c = p.children;
+    std::array<cube, 8> &c = *p.children;
     int d = DIMENSION(orient),
         dc = DIM_COORD(orient),
         texs[4] = { -1, -1, -1, -1 },
@@ -410,7 +412,7 @@ int getmippedtexture(const cube &p, int orient)
 
 void forcemip(cube &c, bool fixtex)
 {
-    cube *ch = c.children;
+    std::array<cube, 8> &ch = *c.children;
     setcubefaces(c, faceempty);
     for(int i = 0; i < 8; ++i)
     {
@@ -505,16 +507,17 @@ bool subdividecube(cube &c, bool fullcheck, bool brighten)
         {
             for(int l = 0; l < 6; ++l) //note this is a loop l (level 4)
             {
-                c.children[i].texture[l] = c.texture[l];
+                (*c.children)[i].texture[l] = c.texture[l];
             }
             if(brighten && !(c.isempty()))
             {
-                brightencube(c.children[i]);
+                brightencube((*c.children)[i]);
             }
         }
         return true;
     }
-    cube *ch = c.children = newcubes(facesolid, c.material);
+    c.children = newcubes(facesolid, c.material);
+    std::array<cube, 8> &ch = *c.children;
     bool perfect = true;
     ivec v[8];
     for(int i = 0; i < 8; ++i)
@@ -571,7 +574,7 @@ bool subdividecube(cube &c, bool fullcheck, bool brighten)
         }
     }
 
-    validatec(ch);
+    validatec(c.children);
     if(fullcheck)
     {
         for(int i = 0; i < 8; ++i)
@@ -624,15 +627,20 @@ VAR(mipvis, 0, 0, 1);
 
 static bool remip(cube &c, const ivec &co, int size)
 {
-    cube *ch = c.children;
-    if(!ch)
+    std::array<cube, 8> dummy = {}; //need something to refer to (will never be used)
+    std::array<cube, 8> &ch = dummy;
+    if(!c.children)
     {
         if(size<<1 <= 0x1000)
         {
             return true;
         }
         subdividecube(c);
-        ch = c.children;
+        ch = *c.children;
+    }
+    else
+    {
+        ch = *c.children;
     }
     bool perfect = true;
     for(int i = 0; i < 8; ++i)
@@ -697,19 +705,19 @@ static bool remip(cube &c, const ivec &co, int size)
         freeocta(n.children);
         return false;
     }
-    cube *nh = n.children;
+    std::array<cube, 8> *&nh = n.children;
     uchar vis[6] = {0, 0, 0, 0, 0, 0};
     for(int i = 0; i < 8; ++i)
     {
-        if(ch[i].faces[0] != nh[i].faces[0] ||
-           ch[i].faces[1] != nh[i].faces[1] ||
-           ch[i].faces[2] != nh[i].faces[2])
+        if(ch[i].faces[0] != (*nh)[i].faces[0] ||
+           ch[i].faces[1] != (*nh)[i].faces[1] ||
+           ch[i].faces[2] != (*nh)[i].faces[2])
         {
             freeocta(nh);
             return false;
         }
 
-        if(ch[i].isempty() && nh[i].isempty())
+        if(ch[i].isempty() && (*nh)[i].isempty())
         {
             continue;
         }
@@ -772,9 +780,9 @@ void cubeworld::remip()
     for(int i = 0; i < 8; ++i)
     {
         ivec o(i, ivec(0, 0, 0), mapsize()>>1);
-        ::remip(worldroot[i], o, mapsize()>>2);
+        ::remip((*worldroot)[i], o, mapsize()>>2);
     }
-    worldroot->calcmerges(worldroot); //created as result of calcmerges being cube member
+    (*worldroot)[0].calcmerges(&(*worldroot)[0]); //created as result of calcmerges being cube member
 }
 
 const ivec cubecoords[8] =
@@ -1233,7 +1241,7 @@ static bool occludesface(const cube &c, int orient, const ivec &o, int size, con
     {
         if(OCTA_COORD(dim, i) == coord)
         {
-            if(!occludesface(c.children[i], orient, ivec(i, o, size), size, vo, vsize, vmat, nmat, matmask, vf, numv))
+            if(!occludesface((*c.children)[i], orient, ivec(i, o, size), size, vo, vsize, vmat, nmat, matmask, vf, numv))
             {
                 return false;
             }
@@ -1732,7 +1740,7 @@ void cube::mincubeface(const cube &cu, int orient, const ivec &o, int size, cons
         {
             if(OCTA_COORD(dim, i) == coord)
             {
-                mincubeface(cu.children[i], orient, ivec(i, o, size), size, orig, cf, nmat, matmask);
+                mincubeface((*cu.children)[i], orient, ivec(i, o, size), size, orig, cf, nmat, matmask);
             }
         }
         return;
@@ -1868,7 +1876,7 @@ void invalidatemerges(cube &c)
     {
         for(int i = 0; i < 8; ++i)
         {
-            invalidatemerges(c.children[i]);
+            invalidatemerges((*c.children)[i]);
         }
     }
 }

--- a/src/engine/world/octaworld.h
+++ b/src/engine/world/octaworld.h
@@ -200,15 +200,15 @@ enum
     ViewFrustumCull_NotVisible,
 };
 
-extern cube *newcubes(uint face = faceempty, int mat = Mat_Air);
+extern std::array<cube, 8> *newcubes(uint face = faceempty, int mat = Mat_Air);
 extern cubeext *growcubeext(cubeext *ext, int maxverts);
 extern void setcubeext(cube &c, cubeext *ext);
 extern cubeext *newcubeext(cube &c, int maxverts = 0, bool init = true);
 extern void getcubevector(const cube &c, int d, int x, int y, int z, ivec &p);
 extern void setcubevector(cube &c, int d, int x, int y, int z, const ivec &p);
 extern int familysize(const cube &c);
-extern void freeocta(cube *c);
-extern void validatec(cube *c, int size = 0);
+extern void freeocta(std::array<cube, 8> *&c);
+extern void validatec(std::array<cube, 8> *&c, int size = 0);
 
 extern const cube *neighborstack[32];
 extern int neighbordepth;

--- a/src/engine/world/raycube.cpp
+++ b/src/engine/world/raycube.cpp
@@ -275,13 +275,15 @@ bool insideworld(const ivec &o)
 vec hitsurface;
 
 //==================INITRAYCUBE CHECKINSIDEWORLD DOWNOCTREE FINDCLOSEST UPOCTREE
+
+//NOTE: levels[20] magically assumes mapscale <20
 #define INITRAYCUBE \
     float dist = 0, \
           dent = radius > 0 ? radius : 1e16f; \
     vec v(o), \
         invray(ray.x ? 1/ray.x : 1e16f, ray.y ? 1/ray.y : 1e16f, ray.z ? 1/ray.z : 1e16f); \
     cube *levels[20]; \
-    levels[worldscale] = worldroot; \
+    levels[worldscale] = &(*worldroot)[0]; \
     int lshift = worldscale, \
         elvl = mode&Ray_BB ? worldscale : 0; \
     ivec lsizemask(invray.x>0 ? 1 : 0, invray.y>0 ? 1 : 0, invray.z>0 ? 1 : 0); \
@@ -341,7 +343,7 @@ bool cubeworld::checkinsideworld(const vec &invray, float radius, float &outrad,
             { \
                 break; \
             } \
-            lc = lc->children; \
+            lc = &(*lc->children)[0]; \
             levels[lshift] = lc; \
         }
 

--- a/src/engine/world/world.cpp
+++ b/src/engine/world/world.cpp
@@ -153,10 +153,9 @@ void attachentity(extentity &e)
 //used in iengine
 void attachentities()
 {
-    std::vector<extentity *> &ents = entities::getents();
-    for(uint i = 0; i < ents.size(); i++)
+    for(extentity *& i : entities::getents())
     {
-        attachentity(*ents[i]);
+        attachentity(*i);
     }
 }
 
@@ -308,7 +307,7 @@ static bool getentboundingbox(const extentity &e, ivec &o, ivec &r)
     return true;
 }
 
-static void modifyoctaentity(int flags, int id, const extentity &e, cube *c, const ivec &cor, int size, const ivec &bo, const ivec &br, int leafsize, vtxarray *lastva = nullptr)
+static void modifyoctaentity(int flags, int id, const extentity &e, std::array<cube, 8> &c, const ivec &cor, int size, const ivec &bo, const ivec &br, int leafsize, vtxarray *lastva = nullptr)
 {
     LOOP_OCTA_BOX(cor, size, bo, br)
     {
@@ -316,7 +315,7 @@ static void modifyoctaentity(int flags, int id, const extentity &e, cube *c, con
         vtxarray *va = c[i].ext && c[i].ext->va ? c[i].ext->va : lastva;
         if(c[i].children != nullptr && size > leafsize)
         {
-            modifyoctaentity(flags, id, e, c[i].children, o, size>>1, bo, br, leafsize, va);
+            modifyoctaentity(flags, id, e, *(c[i].children), o, size>>1, bo, br, leafsize, va);
         }
         else if(flags&ModOctaEnt_Add)
         {
@@ -519,7 +518,7 @@ bool cubeworld::modifyoctaent(int flags, int id, extentity &e)
         {
             leafsize *= 2;
         }
-        modifyoctaentity(flags, id, e, worldroot, ivec(0, 0, 0), mapsize()>>1, o, r, leafsize);
+        modifyoctaentity(flags, id, e, *worldroot, ivec(0, 0, 0), mapsize()>>1, o, r, leafsize);
     }
     e.flags ^= EntFlag_Octa;
     switch(e.type)
@@ -636,7 +635,7 @@ void entselectionbox(const entity &e, vec &eo, vec &es)
 
 ////////////////////////////// world size/octa /////////////////////////////////
 
-static void splitocta(cube *c, int size)
+static void splitocta(std::array<cube, 8> &c, int size)
 {
     if(size <= 0x1000)
     {
@@ -648,7 +647,7 @@ static void splitocta(cube *c, int size)
         {
             c[i].children = newcubes(c[i].isempty() ? faceempty : facesolid);
         }
-        splitocta(c[i].children, size>>1);
+        splitocta(*(c[i].children), size>>1);
     }
 }
 
@@ -686,11 +685,11 @@ bool cubeworld::emptymap(int scale, bool force, bool usecfg)    // main empty wo
     worldroot = newcubes(faceempty);
     for(int i = 0; i < 4; ++i)
     {
-        setcubefaces(worldroot[i], facesolid);
+        setcubefaces((*worldroot)[i], facesolid);
     }
     if(mapsize() > 0x1000)
     {
-        splitocta(worldroot, mapsize()>>1);
+        splitocta(*worldroot, mapsize()>>1);
     }
     clearmainmenu();
     if(usecfg)
@@ -714,17 +713,17 @@ bool cubeworld::emptymap(int scale, bool force, bool usecfg)    // main empty wo
 bool cubeworld::enlargemap(bool force)
 {
     worldscale++;
-    cube *c = newcubes(faceempty);
-    c[0].children = worldroot;
+    std::array<cube, 8> *c = newcubes(faceempty);
+    (*c)[0].children = worldroot;
     for(int i = 0; i < 3; ++i)
     {
-        setcubefaces(c[i+1], facesolid);
+        setcubefaces((*c)[i+1], facesolid);
     }
     worldroot = c;
 
     if(mapsize() > 0x1000)
     {
-        splitocta(worldroot, mapsize()>>1);
+        splitocta(*worldroot, mapsize()>>1);
     }
     allchanged();
     return true;
@@ -747,7 +746,7 @@ static bool isallempty(const cube &c)
     }
     for(int i = 0; i < 8; ++i)
     {
-        if(!isallempty(c.children[i]))
+        if(!isallempty((*c.children)[i]))
         {
             return false;
         }
@@ -774,7 +773,7 @@ void cubeworld::shrinkmap()
     int octant = -1;
     for(int i = 0; i < 8; ++i)
     {
-        if(!isallempty(worldroot[i]))
+        if(!isallempty((*worldroot)[i]))
         {
             if(octant >= 0)
             {
@@ -787,12 +786,12 @@ void cubeworld::shrinkmap()
     {
         return;
     }
-    if(!worldroot[octant].children)
+    if(!(*worldroot)[octant].children)
     {
-        subdividecube(worldroot[octant], false, false);
+        subdividecube((*worldroot)[octant], false, false);
     }
-    cube *root = worldroot[octant].children; //change worldroot to cube 0
-    worldroot[octant].children = nullptr; //free the old largest cube
+    std::array<cube, 8> *&root = (*worldroot)[octant].children; //change worldroot to cube 0
+    (*worldroot)[octant].children = nullptr; //free the old largest cube
     freeocta(worldroot);
     worldroot = root;
     worldscale--;

--- a/src/engine/world/worldio.cpp
+++ b/src/engine/world/worldio.cpp
@@ -183,7 +183,7 @@ enum OctaSave
 
 static int savemapprogress = 0;
 
-void cubeworld::savec(const cube * const c, const ivec &o, int size, stream * const f)
+void cubeworld::savec(const std::array<cube, 8> &c, const ivec &o, int size, stream * const f)
 {
     if((savemapprogress++&0xFFF)==0)
     {
@@ -195,7 +195,7 @@ void cubeworld::savec(const cube * const c, const ivec &o, int size, stream * co
         if(c[i].children) //recursively note existence of children & call this fxn again
         {
             f->putchar(OctaSave_Children);
-            savec(c[i].children, co, size>>1, f);
+            savec(*(c[i].children), co, size>>1, f);
         }
         else //once we're done with all cube children within cube *c given
         {
@@ -265,7 +265,8 @@ void cubeworld::savec(const cube * const c, const ivec &o, int size, stream * co
                     {
                         surfaceinfo surf = c[i].ext->surfaces[j];
                         vertinfo *verts = c[i].ext->verts() + surf.verts;
-                        int layerverts = surf.numverts&Face_MaxVerts, numverts = surf.totalverts(),
+                        int layerverts = surf.numverts&Face_MaxVerts,
+                            numverts = surf.totalverts(),
                             vertmask   = 0,
                             vertorder  = 0,
                             dim = DIMENSION(j),
@@ -367,7 +368,7 @@ void cubeworld::savec(const cube * const c, const ivec &o, int size, stream * co
     }
 }
 
-cube *loadchildren(stream *f, const ivec &co, int size, bool &failed);
+std::array<cube, 8> *loadchildren(stream *f, const ivec &co, int size, bool &failed);
 
 void loadc(stream *f, cube &c, const ivec &co, int size, bool &failed)
 {
@@ -534,12 +535,12 @@ void loadc(stream *f, cube &c, const ivec &co, int size, bool &failed)
     }
 }
 
-cube *loadchildren(stream *f, const ivec &co, int size, bool &failed)
+std::array<cube, 8> *loadchildren(stream *f, const ivec &co, int size, bool &failed)
 {
-    cube *c = newcubes();
+    std::array<cube, 8> *c = newcubes();
     for(int i = 0; i < 8; ++i)
     {
-        loadc(f, c[i], ivec(i, co, size), size, failed);
+        loadc(f, (*c)[i], ivec(i, co, size), size, failed);
         if(failed)
         {
             break;
@@ -913,7 +914,7 @@ bool cubeworld::save_world(const char *mname, const char *gameident)
     }
     savevslots(f, numvslots);
     renderprogress(0, "saving octree...");
-    savec(worldroot, ivec(0, 0, 0), rootworld.mapsize()>>1, f);
+    savec(*worldroot, ivec(0, 0, 0), rootworld.mapsize()>>1, f);
     delete f;
     conoutf("wrote map file %s", ogzname);
     return true;

--- a/src/engine/world/worldio.cpp
+++ b/src/engine/world/worldio.cpp
@@ -370,6 +370,25 @@ void cubeworld::savec(const std::array<cube, 8> &c, const ivec &o, int size, str
 
 std::array<cube, 8> *loadchildren(stream *f, const ivec &co, int size, bool &failed);
 
+/**
+ * @param Loads a cube, possibly containing its child cubes.
+ *
+ * Sets the contents of the cube passed depending on the leading flag embedded
+ * in the string.
+ *
+ * If OctaSave_Children, begins recursive loading of cubes into the passed cube's `children` field
+ *
+ * If OctaSave_Empty, clears the cube
+ *
+ * If OctaSave_Solid, fills the cube completely
+ *
+ * If OctaSave_Normal, reads and sets the twelve edges of the cube
+ *
+ * If none of these are passed, failed flag is set and nothing is done.
+ *
+ * Once OctaSave_Empty/Solid/Normal has been initiated, loads texture, material,
+ * normal data, and other meta information for the cube c passed
+ */
 void loadc(stream *f, cube &c, const ivec &co, int size, bool &failed)
 {
     static constexpr uint layerdup (1<<7); //if numverts is larger than this, get additional precision
@@ -535,6 +554,14 @@ void loadc(stream *f, cube &c, const ivec &co, int size, bool &failed)
     }
 }
 
+/**
+ * @brief Returns a heap-allocated std::array of cubes read from a file.
+ *
+ * These cubes must be freed using freeocta() when destroyed to prevent a leak.
+ *
+ * All eight cubes are read, unless the stream does not contain a valid leading
+ * digit (see OctaSave enum), whereupon all loading thereafter is not executed.
+ */
 std::array<cube, 8> *loadchildren(stream *f, const ivec &co, int size, bool &failed)
 {
     std::array<cube, 8> *c = newcubes();


### PR DESCRIPTION

This pull request replaces the C arrays `cube[8]` comprising the octree with `std::array<cube, 8>`. This applies to the `cubeworld` object as well as the children of all `cube` objects, thus modifying the structure of both of those classes.

Methods and functions which take a parameter of type `cube *` or `cube &` which in fact iterate over a series of `cube` objects using direct array iteration now will take `std::array<cube, 8>` or some pointer/reference/`const` derivative thereof to make it clear which functions need contiguous `cube` objects following the passed parameter. This includes many functions that would naively appear to operate on specific cubes.

The two objects which contain octets of cube objects will now store, specifically, a single pointer to a heap-allocated `std::array<cube, 8>`, which changes the access semantics due to the lack of direct pointer access to the elements that a C array has. This means that many instances of cube child access now requre additional dereferencing to access or modify.