### PR TITLE
Update CI dependencies and configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
 

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -22,7 +22,7 @@ jobs:
       run: make CXX=clang CPP_20=1 -C src -j4
 
     - name: Upload libprimis.so artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: libprimis-linux
         path: ./src/libprimis.so

--- a/.github/workflows/doxyfile.yml
+++ b/.github/workflows/doxyfile.yml
@@ -20,7 +20,7 @@ jobs:
     steps:     
       
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # Get the libprimis-header submodules.
           submodules: true

--- a/.github/workflows/doxyfile.yml
+++ b/.github/workflows/doxyfile.yml
@@ -9,6 +9,18 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "run-doxygen"

--- a/.github/workflows/doxyfile.yml
+++ b/.github/workflows/doxyfile.yml
@@ -61,7 +61,7 @@ jobs:
           publish_dir: ./docs
 
       - name: Upload man pages
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: libprimis-doc
           path: ./doc/man/man3/

--- a/.github/workflows/doxyfile.yml
+++ b/.github/workflows/doxyfile.yml
@@ -52,13 +52,16 @@ jobs:
       # Show what files were created. Nice for debugging.
       - run: ls --recursive
       
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          # Provide a GitHub token to authenticate pushing files.
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Push documentation files in docs folder to gh-pages repo.
-          publish_dir: ./docs
+          # Upload _site/ directory
+          path: 'docs'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
       - name: Upload man pages
         uses: actions/upload-artifact@v4

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
 

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -22,7 +22,7 @@ jobs:
       run: make -C src -j4
 
     - name: Upload libprimis.so artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: libprimis-linux
         path: ./src/libprimis.so

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Clone repository and submodules
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -36,7 +36,7 @@ jobs:
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
       
     - name: Upload libprimis.lib artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: libprimis-windows
         path: ./bin64/libprimis.lib

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -22,7 +22,7 @@ jobs:
         submodules: true
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.3.1
 
 #     errors due to this project not using NuGet
 #    - name: Restore NuGet packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
 


### PR DESCRIPTION
This PR updates the GitHub Actions dependencies for Libprimis build and documentation CI.

To automate CI dependency updates, Dependabot integration has been added, though `Dependabot version updates` may need to be switched on in the [repository security settings](https://github.com/project-imprimis/libprimis/settings/security_analysis).

It also replaces the old GitHub Pages tool, which pushes deployments to a branch of the repository, with the new artifact-based system. This will require that the [repository Pages source](https://github.com/project-imprimis/libprimis/settings/pages) is set to `GitHub Actions`.